### PR TITLE
Fix manpage generation

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,8 @@ OCamlbuild NEXT_RELEASE
   (Vincent Laporte)
 - #20: add -dot and -man-related ocamldoc options
   (Gabriel Scherer)
+- #10, PR#21: Fix manpages generation: properly pass the "manpage" tag.
+  (Armaël Guéneau)
 
 
 

--- a/src/ocaml_specific.ml
+++ b/src/ocaml_specific.ml
@@ -432,6 +432,7 @@ rule "ocamldoc: document ocaml project odocl & *odoc -> docdir (man)"
   ~dep:"%.odocl"
   ?doc:None (* TODO document *)
   (Ocaml_tools.document_ocaml_project
+      ~tags:["manpage"]
       ~ocamldoc:Ocaml_tools.ocamldoc_l_dir "%.odocl" "%.docdir/man" "%.docdir");;
 
 rule "ocamldoc: document ocaml project odocl & *odoc -> man|latex|dot..."

--- a/src/ocaml_tools.ml
+++ b/src/ocaml_tools.ml
@@ -139,7 +139,8 @@ let document_ocaml_implem ml odoc env build =
   Ocaml_compiler.prepare_compile build ml;
   ocamldoc_c (tags_of_pathname ml++"implem") ml odoc
 
-let document_ocaml_project ?(ocamldoc=ocamldoc_l_file) odocl docout docdir env build =
+let document_ocaml_project
+    ?(ocamldoc=ocamldoc_l_file) ?(tags = []) odocl docout docdir env build =
   let odocl = env odocl and docout = env docout and docdir = env docdir in
   let contents = string_list_of_file odocl in
   let include_dirs = Pathname.include_dirs_of (Pathname.dirname odocl) in
@@ -148,7 +149,10 @@ let document_ocaml_project ?(ocamldoc=ocamldoc_l_file) odocl docout docdir env b
       expand_module include_dirs module_name ["odoc"]
     end contents in
   let module_paths = List.map Outcome.good (build to_build) in
-  let tags = (Tags.union (tags_of_pathname docout) (tags_of_pathname docdir))++"ocaml" in
+  let tags =
+    Tags.union
+      ((Tags.of_list tags) ++ "ocaml")
+      (Tags.union (tags_of_pathname docout) (tags_of_pathname docdir)) in
   ocamldoc tags module_paths docout docdir
 
 let camlp4 ?(default=A"camlp4o") tag i o env build =

--- a/src/ocaml_tools.mli
+++ b/src/ocaml_tools.mli
@@ -30,6 +30,7 @@ val document_ocaml_interf : string -> string -> Rule.action
 val document_ocaml_implem : string -> string -> Rule.action
 val document_ocaml_project :
   ?ocamldoc:(Tags.t -> string list -> string -> string -> Command.t) ->
+  ?tags:(string list) ->
   string -> string -> string -> Rule.action
 
 val camlp4 : ?default:Command.spec -> Tags.elt -> Pathname.t -> Pathname.t -> Rule.action


### PR DESCRIPTION
Add an optional [tags] parameter to [Ocaml_tools.document_ocaml_project],
as for manpages generation we cannot rely on extension-based tag rules to
add the "manpage" tag.