### PR TITLE
[RFC] warn on second call to the dispatch function

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,11 @@ should not be necessary anymore to have identical
 `foo.{mllib,mldylib}` files, only `foo.mllib` should suffice. See the
 detailed changelog below for details.
 
+- #30: emit a warning if several calls are made to
+   `Ocamlbuild_plugin.dispatch` -- all calls before the last one are
+   ignored, which may not be what users expect.
+  (Gabriel Scherer, review by whitequark)
+
 - #111: added "nostdlib" flag for corresponding ocaml{c,opt} options
   (Thomas Wood)
 


### PR DESCRIPTION
It is an embarrassing shortcoming of the plugin-tags work that calling the `dispatch` function several times just silently overrides its behaviour. Forcing users to call `dispatch` exactly once may be the right interface to expose, but not saying anything if they make a mistake is bad usability.

One approach would be to keep a queue of hooks, push each new hook, and call them in order at dispatch time. I decided _not_ to do that, however, because that would encourage an imperative way to provide functionality, with each plugin doing its own `dispatch` call; this would be fairly fragile as (1) users would have little control over the ordering on plugin rules and (2) they would have to jump through hoops to make sure the plugins are really linked, otherwise their effect would get silently dropped.

By forcing that there is at most one dispatch call, we in fact enforce a pure, declarative interface between plugin providers and plugin users. This has worked out rather well in practice (despite the subpar usability of the current code), see [js_of_ocaml ocamlbuild plugin](https://ocsigen.org/js_of_ocaml/api/Ocamlbuild_js_of_ocaml) for example.

This PR keeps this current interface of having a single dispatch call, but adds a warning each time a previously installed hook is discarded. (The formatted warning text is rather painful to read, so I will probably convert it to one of Daniel's Bünzli nice formatting functions instead.)
