### PR TITLE
generic dependencies: 'link_dep' linking dependency rule

### DIFF
--- a/src/ocaml_specific.ml
+++ b/src/ocaml_specific.ml
@@ -789,7 +789,6 @@ flag ["ocaml"; "absname"; "infer_interface"] (A "-absname");;
 flag ["ocaml"; "byte"; "compile"; "compat_32";] (A "-compat-32");;
 flag ["ocaml";"compile";"native";"asm"] & S [A "-S"];;
 
-
 (* threads, with or without findlib *)
 flag ["ocaml"; "compile"; "thread"] (A "-thread");;
 flag ["ocaml"; "link"; "thread"] (A "-thread");;
@@ -851,5 +850,8 @@ pflag ["ocaml"; "doc"; "manpage"] "man_section"
 
 ocaml_lib "ocamlbuildlib";;
 ocaml_lib "ocamlbuildlightlib";;
+
+(* generic dependency rules *)
+pdep ["link"; "link_with"] "link_dep" (fun param -> [param]);;
 
 end in ()

--- a/testsuite/internal.ml
+++ b/testsuite/internal.ml
@@ -321,4 +321,25 @@ let () = test "OpenDependencies"
   ~matching:[M.f "b.byte"]
   ~targets:("b.byte",[]) ();;
 
+let () = test "LinkCStubs"
+  ~description:"Build a simple project that links with C stubs"
+  ~options:[`no_ocamlfind]
+  ~tree:[
+    T.f "a.ml" ~content: "external hello_world : unit -> unit = \"hello_world\";; let () = hello_world ();;";
+    T.f "b.c" ~content:{|
+#include <stdio.h>
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+CAMLprim value hello_world(value unit)
+{
+  CAMLparam1 (unit);
+  printf("Hello World!\n");
+  CAMLreturn (Val_unit);
+}
+|};
+    T.f "_tags" ~content:{|"a.byte": link_dep(b.o),custom|};
+  ]
+  ~matching:[M.f "a.byte"]
+  ~targets:("a.byte", []) ();;
+
 run ~root:"_test_internal";;


### PR DESCRIPTION
OCamlbuild comes with a fair number of built-in flags and parametrized
flags (flag, pflag), but with no built-in dependency rule. This
omission makes it difficult in particular for people to understand how
to build mixed OCaml/C program, as they have to add their own linking
rules (for C object modules) to myocamlbuild.ml.

This commit goes a first step towards more usable generic dependency
rules by adding a generic link-time dependency. In _tags,

    pred: link_dep(foo)

will add "foo" as dependency to all targets matching "pred", and add
"foo" as a link-time argument to linking actions performed to produce
those targets. In particular,

    "foo.byte": link_dep(foo.o), custom
    "foo.native": link_dep(foo.o)

is what should be used to link C stubs into an OCaml executable.