### PR TITLE
An opam-ready build system?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@
 *.out
 *.out.dSYM
 
+ocamlbuild.install
+
 /src/ocamlbuild_config.ml
 /src/lexers.ml
 /src/glob_lexer.ml

--- a/META
+++ b/META
@@ -1,0 +1,7 @@
+# Specification for the "ocamlbuild" library
+requires = "unix"
+version = "[distributed with Ocaml]"
+description = "ocamlbuild support library"
+directory= "^"
+archive(byte) = "ocamlbuildlib.cma"
+archive(native) = "ocamlbuildlib.cmxa"

--- a/META
+++ b/META
@@ -2,6 +2,5 @@
 requires = "unix"
 version = "0.9"
 description = "ocamlbuild support library"
-directory= "^"
 archive(byte) = "ocamlbuildlib.cma"
 archive(native) = "ocamlbuildlib.cmxa"

--- a/META
+++ b/META
@@ -1,6 +1,6 @@
 # Specification for the "ocamlbuild" library
 requires = "unix"
-version = "[distributed with Ocaml]"
+version = "0.9"
 description = "ocamlbuild support library"
 directory= "^"
 archive(byte) = "ocamlbuildlib.cma"

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ installopt_really:
 	$(OCAMLOPT) -for-pack Ocamlbuild_pack $(COMPFLAGS) -c $<
 
 clean::
-	rm -f src/*.cm? *.$(O) *.cm* *.$(A)
+	rm -f src/*.cm? src/*.$(O) *.cm* *.$(O) *.$(A)
 	rm -f *.byte *.native
 	rm -f test/test2/vivi.ml
 

--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,14 @@ INSTALL_LIB_OPT=\
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)/ocamlbuild
 INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
 
-all: ocamlbuild.byte ocamlbuildlib.cma
+byte: ocamlbuild.byte ocamlbuildlib.cma
                  # ocamlbuildlight.byte ocamlbuildlightlib.cma
-allopt: ocamlbuild.native ocamlbuildlib.cmxa
+native: ocamlbuild.native ocamlbuildlib.cmxa
+
+all: byte native
+
+# compatibility alias
+allopt: all
 
 # The executables
 

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@
 #                                                                       #
 #########################################################################
 
-OCAMLC    ?= ocamlc
-OCAMLOPT  ?= ocamlopt
-OCAMLDEP  ?= ocamldep
-OCAMLLEX  ?= ocamllex
+OCAMLC    ?= ocamlc.opt
+OCAMLOPT  ?= ocamlopt.opt
+OCAMLDEP  ?= ocamldep.opt
+OCAMLLEX  ?= ocamllex.opt
 CP        ?= cp
 COMPFLAGS ?= -w L -w R -w Z -I src -I +unix -safe-string
 LINKFLAGS ?= -I +unix -I src

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,9 @@ install:
 installopt:
 	if test -f ocamlbuild.native; then $(MAKE) installopt_really; fi
 
+findlib-install:
+	ocamlfind install ocamlbuild META $(INSTALL_LIB)
+
 installopt_really:
 	$(CP) ocamlbuild.native $(INSTALL_BINDIR)/ocamlbuild$(EXE)
 	$(CP) ocamlbuild.native $(INSTALL_BINDIR)/ocamlbuild.native$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ OCAMLOPT  = ocamlopt
 OCAMLDEP  = ocamldep
 OCAMLLEX  = ocamllex
 CP        = cp
-COMPFLAGS= -warn-error A -w L -w R -w Z -I src -I +unix -safe-string
-LINKFLAGS= -I +unix -I src
+COMPFLAGS = -w L -w R -w Z -I src -I +unix -safe-string
+LINKFLAGS = -I +unix -I src
 
 LIBDIR=$(shell ocamlc -where)
 BINDIR?=/usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ LINKFLAGS ?= -I +unix -I src
 LIBDIR ?= $(shell opam config var lib)
 BINDIR ?= $(shell opam config var bin)
 
+# see 'check-not-preinstalled' target
+CHECK_NOT_PREINSTALLED ?= true
+
 OCAMLBUILD_LIBDIR:=$(LIBDIR)
 OCAMLBUILD_BINDIR:=$(BINDIR)
 
@@ -312,19 +315,33 @@ uninstall-lib:
 uninstall-lib-findlib:
 	ocamlfind remove ocamlbuild
 
-install: install-bin install-lib
+install: check-not-preinstalled
+	$(MAKE) install-bin install-lib
 uninstall: uninstall-bin uninstall-lib
 
-findlib-install: install-bin install-lib-findlib
+findlib-install: check-not-preinstalled
+	$(MAKE) install-bin install-lib-findlib
 findlib-uninstall: uninstall-bin uninstall-lib-findlib
 
-opam-install: ocamlbuild.install
+opam-install: check-not-preinstalled
+	$(MAKE) ocamlbuild.install
 
 ocamlbuild.install:
 	rm -f ocamlbuild.install
 	touch ocamlbuild.install
 	$(MAKE) install-bin-opam
 	$(MAKE) install-lib-opam
+
+check-not-preinstalled:
+	@if test "$(CHECK_NOT_PREINSTALLED)" = "true"; then\
+	  if test -d $(shell ocamlc -where)/ocamlbuild; then\
+	    >&2 echo "ERROR: Preinstalled ocamlbuild detected at"\
+	         "$(shell ocamlc -where)/ocamlbuild";\
+	    >&2 echo "Installation aborted; if you want to bypass"\
+	          "this safety check, set CHECK_NOT_PREINSTALLED=false";\
+	    exit 2;\
+	  fi;\
+	fi
 
 # The generic rules
 

--- a/Makefile.create_config
+++ b/Makefile.create_config
@@ -11,7 +11,7 @@
 #                                                                       #
 #########################################################################
 
-include $(LIBDIR)/Makefile.config
+include $(shell ocamlc -where)/Makefile.config
 
 .PHONY: force
 

--- a/ocamlbuild.install
+++ b/ocamlbuild.install
@@ -1,4 +1,0 @@
-bin: [
-  "?ocamlbuild.native" {"ocamlbuild"}
-  "ocamlbuild.byte" {"ocamlbuild.byte"}
-]

--- a/ocamlbuild.install
+++ b/ocamlbuild.install
@@ -1,0 +1,4 @@
+bin: [
+  "?ocamlbuild.native" {"ocamlbuild"}
+  "ocamlbuild.byte" {"ocamlbuild.byte"}
+]

--- a/opam
+++ b/opam
@@ -23,3 +23,5 @@ doc: [
 
 available: [ocaml-version >= "4.03"]
 depends: [ ]
+
+version: "dev"

--- a/opam
+++ b/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "ocamlbuild"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+
+authors: [
+  "Nicolas Pouillard"
+  "Berke Durak"
+]
+
+license: "LGPL-2 with OCaml linking exception"
+dev-repo: "https://github.com/ocaml/ocamlbuild.git"
+homepage: "https://github.com/ocaml/ocamlbuild/"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+
+build: [
+  [make]
+  [make "ocamlbuild.native"]
+]
+
+# TODO
+# install: [ ]
+
+doc: [
+  "http://caml.inria.fr/pub/docs/manual-ocaml/ocamlbuild.html"
+  "https://github.com/gasche/manual-ocamlbuild/blob/master/manual.md"
+]
+
+available: [ocaml-version >= "4.03"]

--- a/opam
+++ b/opam
@@ -13,12 +13,11 @@ homepage: "https://github.com/ocaml/ocamlbuild/"
 bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
 
 build: [
-  [make]
-  [make "ocamlbuild.native"]
+  [make "NATIVE=%{ocaml-native}%" "all"]
 ]
 
-install: [make "findlib-install"]
-remove: ["ocamlfind" "remove" "ocamlbuild"]
+install: [make "NATIVE=%{ocaml-native}%" "install"]
+remove: [make "NATIVE=%{ocaml-native}%" "uninstall"]
 
 doc: [
   "http://caml.inria.fr/pub/docs/manual-ocaml/ocamlbuild.html"
@@ -26,5 +25,4 @@ doc: [
 ]
 
 available: [ocaml-version >= "4.03"]
-
-depends: [ "ocamlfind" {build} ]
+depends: [ ]

--- a/opam
+++ b/opam
@@ -17,8 +17,8 @@ build: [
   [make "ocamlbuild.native"]
 ]
 
-# TODO
-# install: [ ]
+install: [make "findlib-install"]
+remove: ["ocamlfind" "remove" "ocamlbuild"]
 
 doc: [
   "http://caml.inria.fr/pub/docs/manual-ocaml/ocamlbuild.html"
@@ -26,3 +26,5 @@ doc: [
 ]
 
 available: [ocaml-version >= "4.03"]
+
+depends: [ "ocamlfind" {build} ]

--- a/opam
+++ b/opam
@@ -13,11 +13,8 @@ homepage: "https://github.com/ocaml/ocamlbuild/"
 bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
 
 build: [
-  [make "NATIVE=%{ocaml-native}%" "all"]
+  [make "NATIVE=%{ocaml-native}%" "BINDIR=%{bin}%" "LIBDIR=%{lib}%" "all" "opam-install"]
 ]
-
-install: [make "NATIVE=%{ocaml-native}%" "install"]
-remove: [make "NATIVE=%{ocaml-native}%" "uninstall"]
 
 doc: [
   "http://caml.inria.fr/pub/docs/manual-ocaml/ocamlbuild.html"

--- a/opam
+++ b/opam
@@ -13,7 +13,8 @@ homepage: "https://github.com/ocaml/ocamlbuild/"
 bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
 
 build: [
-  [make "NATIVE=%{ocaml-native}%" "BINDIR=%{bin}%" "LIBDIR=%{lib}%" "all" "opam-install"]
+  [make "NATIVE=%{ocaml-native}%" "BINDIR=%{bin}%" "LIBDIR=%{lib}%"
+        "check-not-preinstalled" "all" "opam-install"]
 ]
 
 doc: [


### PR DESCRIPTION
This PR builds upon @rgrinberg's #29 to provide a hopefully-satisfying installation procedure for ocamlbuild. In the light of #32, I think it is important to get something "releasable in OPAM" as soon as possible, and my hope is that this PR (with modification after review etc.) gives us a "releasable" `Makefile + opam` combination.

The design constraints imposed on the proposed Makefile are:
- it can be used without opam: `make LIBDIR=$(ocamlc -where)/.. BINDIR=/usr/local/bin install uninstall` should work
- it does not require a hard-dependency on ocamlfind (cc @avsm), as it installs the META file itself
- it works in environments that do not have a native compiler available (`make NATIVE=false`)

I incrementally designed three different kinds of install/uninstall targets:
- `install uninstall`, which does (un)installation manually, no findlib dependency (a potential choice for distribution packagers)
- `findlib-install finlib-uninstall`, which uses `ocamlfind {install,remove}` (except for the binaries)
- `opam-install` which does not actually install anything but merely generates an `ocamlbuild.install` file (the choice of scripting the `.install` file generation comes from @dbuenzli's advice in #29 and ocaml/opam#2392)

I tested that the `install uninstall` roundtrip works with and without a native compiler available.

This packaging is not designed to be used with an ocaml distribution that ships ocamlbuild already. The current behavior is that the install targets will override the installed ocamlbuild (binaries and libraries), but that the uninstall targets do not restore the dummy ocamlfind package (then you need to `opam reinstall findlib` to un-break the environment). I don't know for sure whether it is possible and reasonable to try to support this use-case.