### PR TITLE
.o -> .clib rule to build C libraries out of single C stubs

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,6 +20,8 @@ NEXT_RELEASE:
   The most current version of the manual can thus be accessed at
     https://github.com/ocaml/ocamlbuild/tree/master/manual/manual.adoc
   (Gabriel Scherer)
+- new ".o -> .clib" rule to build libraries out of single C stubs
+  (Gabriel Scherer, request by whitequark)
 
 0.9.2 (1 May 2016):
 -------------------

--- a/testsuite/internal.ml
+++ b/testsuite/internal.ml
@@ -362,4 +362,22 @@ let () = test "ForPackEverything"
           T.f "test.ml"  ~content:"let x = 123"; ]
   ~targets:("test.cmo", []) ();;
 
+let () = test "CLibFromCObj"
+  ~description:"Build a C library from a C object file"
+  ~options:[`no_ocamlfind; `no_plugin]
+  ~tree:[
+    T.f "test.c" ~content:{|
+#include <stdio.h>
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+CAMLprim value hello_world(value unit)
+{
+  CAMLparam1 (unit);
+  printf("Hello World!\n");
+  CAMLreturn (Val_unit);
+}
+|};
+  ]
+  ~targets:("libtest.a", []) ();;
+
 run ~root:"_test_internal";;


### PR DESCRIPTION
This pull request implements a feature suggested by #34 : building `libtest.a` out of `test.o` automagically. (Internally it uses the `.clib` mechanism by producing a one-file `.clib` list).

cc @whitequark 
