### PR TITLE
Add support of -custom for toplevel

### DIFF
--- a/src/ocaml_specific.ml
+++ b/src/ocaml_specific.ml
@@ -798,6 +798,7 @@ flag ["ocaml"; "linkall"; "link"] (A "-linkall");;
 flag ["ocaml"; "link"; "profile"; "native"] (A "-p");;
 flag ["ocaml"; "link"; "program"; "custom"; "byte"] (A "-custom");;
 flag ["ocaml"; "link"; "library"; "custom"; "byte"] (A "-custom");;
+flag ["ocaml"; "link"; "toplevel"; "custom"; "byte"] (A "-custom");;
 flag ["ocaml"; "compile"; "profile"; "native"] (A "-p");;
 flag ["ocaml"; "compile"; "no_alias_deps";] (A "-no-alias-deps");;
 flag ["ocaml"; "compile"; "strict_formats";] (A "-strict-formats");;


### PR DESCRIPTION
The `custom` flag was not used while building a custom toplevel.

I don't know if I must add an entry to `Changes`.