### PR TITLE
Better cycle refinement computation

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,8 @@ We also use PR#$N for pull requests.
 OCamlbuild NEXT_RELEASE
 -------------
 
+- #44: When ocamlbuild discover a cycle in the dependencies, the
+   displayed problematic path is now refined to the actual cycle (François Bobot)
 - MPR#6794, MPR#6809: pass package-specific include flags when building C files
   (Jérémie Dimino, request by whitequark)
 - OGPR#208: add "asm" tag to ocamlbuild to enable flag -S

--- a/src/my_std.ml
+++ b/src/my_std.ml
@@ -136,6 +136,22 @@ module List = struct
     in
     List.rev lst
 
+  let index_of x l =
+    let rec aux x n = function
+      | [] -> None
+      | a::_ when a = x -> Some n
+      | _::l -> aux x (n+1) l
+    in
+    aux x 0 l
+
+  let rec split_at n l =
+    let rec aux n acc = function
+      | l when n <= 0 -> List.rev acc, l
+      | [] -> List.rev acc, []
+      | a::l -> aux (n-1) (a::acc) l
+    in
+    aux n [] l
+
 end
 
 module String = struct

--- a/src/ocaml_dependencies.ml
+++ b/src/ocaml_dependencies.ml
@@ -195,66 +195,37 @@ module Make (I : INPUT) = struct
     let dependencies_of x =
       try SMap.find x !*dependencies with Not_found -> Resources.empty in
 
-    let refine_cycle files starting_file =
-      (* We are looking for a cycle starting from [fn], included in
-         [files]; we'll simply use a DFS which builds a path until it
-         finds a circularity.
-
-         Note that if there is at least one cycle going through [fn],
-         calling [dfs path fn] will return it no matter what [path] is
-         (it may just not be the shortest possible cycle). This means
-         that if [dfs path fn] returns [None], [fn] is a dead-end that
-         should never be explored again.
-       *)
-      let dead_ends = ref Resources.empty in
-      let rec dfs path fn =
-        let through_dep f = function
-          | Some _ as cycle -> cycle
-          | None ->
-             if List.mem f path
-             then (* we have found a cycle *)
-               Some (List.rev path)
-             else if not (Resources.mem f files)
-             then
-               (* the neighbor is not in the set of paths known to have a cycle *)
-               None
-             else
-               (* look for cycles going through this neighbor *)
-               dfs (f :: path) f
-        in
-        if Resources.mem fn !dead_ends then None
-        else match Resources.fold through_dep (dependencies_of fn) None with
-          | Some _ as cycle -> cycle
-          | None -> dead_ends := Resources.add fn !dead_ends; None
-      in
-      match dfs [] starting_file with
-        | None -> Resources.elements files
-        | Some cycle -> cycle
-    in
-
     let needed_in_order = ref [] in
     let needed = ref Resources.empty in
     let seen = ref Resources.empty in
-    let rec aux fn =
+    let rec aux on_the_go fn =
       if sys_file_exists fn && not (Resources.mem fn !needed) then begin
-        if Resources.mem fn !seen then
-          raise (Circular_dependencies (refine_cycle !seen fn, fn));
+        if Resources.mem fn !seen then begin
+          begin match List.index_of fn on_the_go with
+            | None -> assert false;
+              (* [on_the_go] is exactly [!seen] without [!needed] *)
+            | Some n ->
+              raise (Circular_dependencies(fst (List.split_at (n+1) on_the_go),
+                                           fn))
+          end;
+        end;
         seen := Resources.add fn !seen;
+        let on_the_go = fn::on_the_go in
         Resources.iter begin fun f ->
           if sys_file_exists f then
             if Filename.check_suffix f ".cmi" then
               let f' = caml_obj_ext_of_cmi f in
               if f' <> fn then
-                if sys_file_exists f' then aux f'
-                else if pack_mode then aux f else ()
+                if sys_file_exists f' then aux on_the_go f'
+                else if pack_mode then aux on_the_go f else ()
               else ()
-            else aux f
+            else aux on_the_go f
         end (dependencies_of fn);
         needed := Resources.add fn !needed;
         needed_in_order := fn :: !needed_in_order
       end
     in
-    List.iter aux fns;
+    List.iter (aux []) fns;
     mydprintf "caml_transitive_closure:@ %a ->@ %a"
       pp_l fns pp_l !needed_in_order;
     List.rev !needed_in_order

--- a/src/ocaml_dependencies.ml
+++ b/src/ocaml_dependencies.ml
@@ -197,19 +197,14 @@ module Make (I : INPUT) = struct
 
     let needed_in_order = ref [] in
     let needed = ref Resources.empty in
-    let seen = ref Resources.empty in
     let rec aux on_the_go fn =
       if sys_file_exists fn && not (Resources.mem fn !needed) then begin
-        if Resources.mem fn !seen then begin
-          begin match List.index_of fn on_the_go with
-            | None -> assert false;
-              (* [on_the_go] is exactly [!seen] without [!needed] *)
-            | Some n ->
-              raise (Circular_dependencies(fst (List.split_at (n+1) on_the_go),
-                                           fn))
-          end;
+        begin match List.index_of fn on_the_go with
+          | None -> () (* good no cycle *)
+          | Some n ->
+            raise (Circular_dependencies(fst (List.split_at (n+1) on_the_go),
+                                         fn))
         end;
-        seen := Resources.add fn !seen;
         let on_the_go = fn::on_the_go in
         Resources.iter begin fun f ->
           if sys_file_exists f then

--- a/src/signatures.mli
+++ b/src/signatures.mli
@@ -36,6 +36,10 @@ module type LIST = sig
   val filter_opt : ('a -> 'b option) -> 'a list -> 'b list
   val union : 'a list -> 'a list -> 'a list
   val ordered_unique : 'a list -> 'a list
+  val index_of: 'a -> 'a list -> int option
+  (** give the offset of an element (0 for the first element) *)
+  val split_at: int -> 'a list -> 'a list * 'a list
+  (** split the list before the element at the given offset *)
   (* Original functions *)
   include module type of List
 end


### PR DESCRIPTION
Currently when circular dependencies are detected the following is printed:
```
Circular build detected
  (src/types.cmx already seen in [ src/types.cmx; src/explanation.cmx;
                                   src/conflict.cmx; src/cmd/popop.cmx;
                                   src/cmd/popop.native ])
```

In this case `Types` was wrongly used in `types.ml`.  It is more informative to have just the cycle:

```
Circular build detected (src/types.cmx already seen in [ src/types.cmx ])
```

This merge request refine the witness by keeping only the cycle. It also simplify a similar refinement done when there is a cycle during the computation of the ocaml files to link.

I just don't know where to put this `refine_cycle` function. At first I wanted to put it in `My_Std.List` but it seems that it should not (cf. #13). So, where should I put it?