### PR TITLE
Release Candidate for 0.9.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,8 +8,8 @@ The form #$N indicates an issue on the github ocamlbuild repository,
   https://github.com/ocaml/ocamlbuild/pulls/$N
 We also use PR#$N for pull requests.
 
-OCamlbuild NEXT_RELEASE
--------------
+OCamlbuild 0.9.0 (19 Jan 2016):
+-------------------------------
 
 - MPR#6794, MPR#6809: pass package-specific include flags when building C files
   (Jérémie Dimino, request by whitequark)

--- a/opam
+++ b/opam
@@ -29,5 +29,6 @@ doc: [
 
 available: [ocaml-version >= "4.03"]
 depends: [ ]
+conflicts: [ "base-ocamlbuild" ]
 
 version: "dev"


### PR DESCRIPTION
In the light of #32 , I am preparing a "development only" release to have in OPAM for people playing with 4.03.0+dev today. I tenatively named it 0.9.0, but haven't done any release (that is, I have not pushed a tag yet). I hope to do that shortly (tomorrow); now is the time to give feedback in case there is anything I missed.

cc @bobot @whitequark and really anyone interested.

I would like to keep notes of what the release process is (current: check the Changes pre-release, push a tag, and then create a new Changes section post-release). I will do that in a `howto/` or `dev/` directory at the root of the repo, but after the release.

I use the version number 0.9.0, in case we have to do some iterations on this "development only" distribution during the 4.03 feature freeze period. I have no updated the VERSION files or `ocamlbuild --version` output, though, that still return `0.9`. Is that a problem I should fix?