### PR TITLE
consider files starting with '_' as source files

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,12 @@ The form #$N indicates an issue on the github ocamlbuild repository,
   https://github.com/ocaml/ocamlbuild/pulls/$N
 We also use PR#$N for pull requests.
 
+NEXT_RELASE:
+------------
+
+- Do not exclude files whose name starts with '_' from the source tree
+  (Gabriel Scherer, report by Daniel Bünzli on the caml-list)
+
 OCamlbuild 0.9.0 (19 Jan 2016):
 -------------------------------
 

--- a/bootstrap/_tags
+++ b/bootstrap/_tags
@@ -21,3 +21,7 @@ true: debug
 "ocamlbuildlight.byte": -use_unix, nopervasives
 <**/*.cmx>: for-pack(Ocamlbuild_pack)
 <**/{ocamlbuild_{pack,unix_plugin,plugin,executor},ppcache}{,.p}.cmx>: -for-pack(Ocamlbuild_pack)
+
+# we have several build stages using different build directories,
+# so each build must ignore each other's build dir.
+<_build*>: -traverse

--- a/src/main.ml
+++ b/src/main.ml
@@ -147,8 +147,7 @@ let proceed () =
           ignore (Configuration.parse_file ?dir tags_path);
         end;
 
-        (List.mem name ["_oasis"] || (String.length name > 0 && name.[0] <> '_'))
-        && (name <> !Options.build_dir && not (List.mem name !Options.exclude_dirs))
+        (name <> !Options.build_dir && not (List.mem name !Options.exclude_dirs))
         && begin
           not (path_name <> Filename.current_dir_name && Pathname.is_directory path_name)
           || begin

--- a/testsuite/internal.ml
+++ b/testsuite/internal.ml
@@ -321,4 +321,16 @@ let () = test "OpenDependencies"
   ~matching:[M.f "b.byte"]
   ~targets:("b.byte",[]) ();;
 
+let () = test "TargetsStartingWithUnderscore"
+  ~description:"Build targets whose name starts with '_'"
+(*
+  requested by Daniel Bünzli on the caml-list:
+     Subject: [Caml-list] ocamlbuild, build a source that starts with _
+     Date: Tue, 9 Feb 2016 14:35:06 +0100
+     https://sympa.inria.fr/sympa/arc/caml-list/2016-02/msg00033.html
+*)
+  ~options:[`no_ocamlfind]
+  ~tree:[ T.f "_a.c" ~content:"" ]
+  ~targets:("_a.o", []) ();;
+
 run ~root:"_test_internal";;


### PR DESCRIPTION
This was requested by Daniel Bünzli on the caml-list:
     Subject: [Caml-list] ocamlbuild, build a source that starts with _
     Date: Tue, 9 Feb 2016 14:35:06 +0100
     https://sympa.inria.fr/sympa/arc/caml-list/2016-02/msg00033.html

It does not make sense for .ml files, as .ml basenames must be valid
OCaml modules, so a .ml file cannot start with _ anyway, but it does
make sense for C files for example.

This commit simply removes the special logic that would disregard
_-starting files when slurping the directory. I suppose this logic was
meant to prevent _oasis, _tags etc. from being considered in build
rules, but I don't see any negative side-effect in undoing it.