### PR TITLE
revert commit 1d8e590 from OCaml (PR#6475)

### DIFF
--- a/src/ocaml_specific.ml
+++ b/src/ocaml_specific.ml
@@ -536,7 +536,9 @@ rule "ocaml C stubs: c -> o"
     let c = env "%.c" in
     let o = env x_o in
     let comp = if Tags.mem "native" (tags_of_pathname c) then !Options.ocamlopt else !Options.ocamlc in
-    Cmd(S[comp; T(tags_of_pathname c++"c"++"compile"); A"-c"; A"-o"; P o; Px c])
+    let cc = Cmd(S[comp; T(tags_of_pathname c++"c"++"compile"); A"-c"; Px c]) in
+    if Pathname.dirname o = Pathname.current_dir_name then cc
+    else Seq[cc; mv (Pathname.basename o) o]
   end;;
 
 rule "ocaml: ml & ml.depends & *cmi -> .inferred.mli"


### PR DESCRIPTION
This reverts the part of ocaml/ocaml@1d8e590c54dcd888503c3ea2944533255ef87343 that was in ocamlbuild.

It's needed because the corresponding feature is (temporarily) removed from OCaml.
