### PR TITLE
quick windows fixes for 4.03

### DIFF
--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -66,9 +66,6 @@ let run_and_parse lexer command =
     (fun command -> lexer & Lexing.from_string & run_and_read command)
     command
 
-let run_and_read command =
-  Printf.ksprintf run_and_read command
-
 let rec query name =
   try
     Hashtbl.find packages name
@@ -135,7 +132,8 @@ let before_space s =
   with Not_found -> s
 
 let list () =
-  List.map before_space (split_nl & run_and_read "%s list" ocamlfind)
+  let cmd = Shell.quote_filename_if_needed ocamlfind ^ " list" in
+  List.map before_space (split_nl & run_and_read cmd)
 
 (* The closure algorithm is easy because the dependencies are already closed
 and sorted for each package. We only have to make the union. We could also

--- a/src/ocamlbuild_unix_plugin.ml
+++ b/src/ocamlbuild_unix_plugin.ml
@@ -48,6 +48,14 @@ let at_exit_once callback =
   end
 
 let run_and_open s kont =
+  let s =
+    (* Be consistent! My_unix.run_and_open uses My_std.sys_command and
+       sys_command uses bash. *)
+    if Sys.win32 then
+      "bash --norc -c " ^ Filename.quote s
+    else
+      s
+  in
   let ic = Unix.open_process_in s in
   let close () =
     match Unix.close_process_in ic with

--- a/src/pathname.ml
+++ b/src/pathname.ml
@@ -84,6 +84,27 @@ let rec normalize_list = function
   | x :: xs -> x :: normalize_list xs
 
 let normalize x =
+  let x =
+    if Sys.win32 = false then
+      x
+    else
+      let len = String.length x in
+      let b = Bytes.create len in
+      let use_bs = ref false in
+      for i = 0 to pred len do
+        match x.[i] with
+        | '\\' -> Bytes.set b i '/'
+        | c -> Bytes.set b i c
+      done;
+      if len > 1 then (
+        let c1 = Bytes.get b 0 in
+        let c2 = Bytes.get b 1 in
+        if c2 = ':' && c1 >= 'a' && c1 <= 'z' &&
+           ( len = 2 || Bytes.get b 2 = '/') then
+          Bytes.set b 0 (Char.uppercase_ascii c1)
+      );
+      Bytes.unsafe_to_string b
+  in
   if Glob.eval not_normal_form_re x then
     let root, paths = split x in
     join root (normalize_list paths)

--- a/src/shell.ml
+++ b/src/shell.ml
@@ -24,12 +24,27 @@ let is_simple_filename s =
     | 'a'..'z' | 'A'..'Z' | '0'..'9' | '.' | '-' | '/' | '_' | ':' | '@' | '+' | ',' -> loop (pos + 1)
     | _ -> false in
   loop 0
+
+
+(* generic_quote and unix_quote are copy&pasted from
+   Ocaml source stdlib/filename.ml.
+   See also mantis issue #6287 *)
+let generic_quote quotequote s =
+  let l = String.length s in
+  let b = Buffer.create (l + 20) in
+  Buffer.add_char b '\'';
+  for i = 0 to l - 1 do
+    if s.[i] = '\''
+    then Buffer.add_string b quotequote
+    else Buffer.add_char b  s.[i]
+  done;
+  Buffer.add_char b '\'';
+  Buffer.contents b
+let unix_quote = generic_quote "'\\''"
+
 let quote_filename_if_needed s =
   if is_simple_filename s then s
-  (* We should probably be using [Filename.unix_quote] except that function
-   * isn't exported. Users on Windows will have to live with not being able to
-   * install OCaml into c:\o'caml. Too bad. *)
-  else if Sys.os_type = "Win32" then Printf.sprintf "'%s'" s
+  else if Sys.os_type = "Win32" then unix_quote s
   else Filename.quote s
 let chdir dir =
   reset_filesys_cache ();


### PR DESCRIPTION
three windows related changes - feel free to cherry-pick:

1) 
`My_unix.run_and_open` will either call the internal My_unix.run_and_open (https://github.com/ocaml/ocamlbuild/blob/982fdf1b9ecf1448f07aa74a43e07db8c410dbd6/src/my_unix.ml#L62) or Ocamlbuild_unix_plugin.run_and_open (https://github.com/ocaml/ocamlbuild/blob/982fdf1b9ecf1448f07aa74a43e07db8c410dbd6/src/ocamlbuild_unix_plugin.ml#L50).

The first function will use bash, the second plain cmd.exe. That's confusing. You can't always know, which function will be called, but you have to quote differently for both cases (`Filename.quote` vs `Shell.quote_filename_if_needed`). It can happen e.g. here: https://github.com/ocaml/ocamlbuild/blob/982fdf1b9ecf1448f07aa74a43e07db8c410dbd6/src/ocaml_specific.ml#L752 `2>/dev/null` is obviously wrong for cmd.exe, but bash.exe will accept it.

2)
Proper shell quoting. The code is copy&pasted from the ocaml source tree, because it is not exported. (See http://caml.inria.fr/mantis/view.php?id=6287 )

3)
Another side effect of allowing file names that starts with '_'. `Hygiene.check` now complains frequently about files under '_build/' (eg. myocamlbuild.cmi). The default build dir is: `let build_dir = ref (Filename.concat (Sys.getcwd ()) "_build")`. `Filename.concat` always use backslashes as path separator. `My_std.filename_concat` (`/`) however uses slashes, therefore the comparison here ( https://github.com/ocaml/ocamlbuild/blob/13feb3cafc1f4f664aca0a744f2f08e30bffd06a/src/main.ml#L162 ) won't return the desired result. (see https://github.com/ocaml/opam-repository/issues/6224 )

I've just changed `Pathname.normalize`, that previously didn't work reliable on windows at all, because only slashes were treated as path separators. It now always return a version of the file name with an uppercase drive letter and only forward slashes. (I've first tried to return a string with backslashes, but the solver didn't like it.)
