### PR TITLE
Add bin-annot flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OCAMLLEX  ?= ocamllex
 endif
 
 CP        ?= cp
-COMPFLAGS ?= -w L -w R -w Z -I src -I +unix -safe-string
+COMPFLAGS ?= -w L -w R -w Z -I src -I +unix -safe-string -bin-annot
 LINKFLAGS ?= -I +unix -I src
 
 PACK_CMO= $(addprefix src/,\


### PR DESCRIPTION
Create .cmt & .cmti files when compiling ocamlbuild. Very helpful when using
with merlin (or ocp-index).

I assume there's no need to check for older functions for OCaml as those would
have a builtin version of ocamlbuild anyway.