### PR TITLE
Ignore node_modules

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -95,7 +95,7 @@ let proceed () =
      <**/*.cmi>: ocaml, byte, native\n\
      <**/*.cmx>: ocaml, native\n\
      <**/*.mly>: infer\n\
-     <**/.svn>|\".bzr\"|\".hg\"|\".git\"|\"_darcs\": -traverse\n\
+     <**/.svn>|\"node_modules\"|\".bzr\"|\".hg\"|\".git\"|\"_darcs\": -traverse\n\
     ";
 
   List.iter

--- a/src/options.ml
+++ b/src/options.ml
@@ -125,7 +125,7 @@ let plugin_tags_internal = ref []
 let log_file_internal = ref "_log"
 
 let my_include_dirs = ref [[Filename.current_dir_name]]
-let my_exclude_dirs = ref [[".svn"; "CVS"]]
+let my_exclude_dirs = ref [["node_modules"; ".svn"; "CVS"]]
 
 let dummy = "*invalid-dummy-string*";; (* Dummy string for delimiting the latest argument *)
 


### PR DESCRIPTION
node_modules is a directory used in yarn (https://yarnpkg.com/) that contains
all the build artifacts of a package's dependencies (similar to _build). To make some ocaml packages installable by node_modules, we should just ignore everything in this directory, like what we did for .git and .svn.