### PR TITLE
Put spaces around `^` for compatibility with macros

### DIFF
--- a/src/command.ml
+++ b/src/command.ml
@@ -369,7 +369,7 @@ let digest =
   fun x ->
     match cmd x [] with
     | [x] -> x
-    | xs  -> Digest.string ("["^String.concat ";" xs^"]")
+    | xs  -> Digest.string ("[" ^ String.concat ";" xs ^ "]")
 
 let all_deps_of_tags = ref []
 

--- a/src/my_std.ml
+++ b/src/my_std.ml
@@ -275,7 +275,7 @@ let sys_command =
   match Sys.os_type with
   | "Win32" -> fun cmd ->
       if cmd = "" then 0 else
-      let cmd = "bash --norc -c "^Filename.quote cmd in
+      let cmd = "bash --norc -c " ^ Filename.quote cmd in
       Sys.command cmd
   | _ -> fun cmd -> if cmd = "" then 0 else Sys.command cmd
 

--- a/src/tools.ml
+++ b/src/tools.ml
@@ -27,7 +27,7 @@ let pp_l = List.print String.print
 let tags_of_pathname p =
   Configuration.tags_of_filename (Pathname.to_string p)
   ++("file:"^p)
-  ++("extension:"^Pathname.get_extension p)
+  ++("extension:" ^ Pathname.get_extension p)
 
 let opt_print elt ppf =
   function


### PR DESCRIPTION
I'm working on a modified version of the compiler with macros, and I would like to install ocamlbuild and various other packages. However, macros introduce a small backward incompatibility. In the following expression:
```ocaml
"some string"^M.some_other_string
```
`^` is no longer parsed as an operator but as part the lifted path `^M.some_other_string`, causing an error.

Even though macros are only a prototype for now, merging this pull request would allow people to install `ocamlbuild` with my modified compiler without having to pin and modify the source.