### PR TITLE
Weird behaviour for pack mlis, breaking on 4.04

### DIFF
--- a/src/ocaml_compiler.ml
+++ b/src/ocaml_compiler.ml
@@ -84,7 +84,7 @@ let ocamlopt_p tags deps out =
     S [!Options.ocamlopt; A"-pack"; forpack_flags out tags; T tags;
        S include_flags; atomize_paths deps;
        A"-o"; Px out] in
-  if (*FIXME true ||*) Pathname.exists mli then Cmd cmd
+  if true || Pathname.exists mli then Cmd cmd
   else
     let rm = S[A"rm"; A"-f"; P mli] in
     Cmd(S[A"touch"; P mli; Sh" ; if "; cmd; Sh" ; then "; rm; Sh" ; else ";


### PR DESCRIPTION
I had a weird error while building dose3 on 4.04, and tracked it down
to this. Disabling the hack seemed to work for me, but it must have
been here for a reason ?

I was getting:
```
Warning 58: no cmx file was found in path for module Common, and its interface was not compiled with -opaque
+ touch algo/algo.mli  ; if  ocamlfind ocamlopt -pack -I algo algo/defaultgraphs.cmx algo/diagnostic.cmx algo/depsolver_int.cmx algo/depsolver.cmx algo/flatten.cmx algo/statistics.cmx algo/dominators.cmx algo/strongdeps.cmx algo/strongconflicts_int.cmx algo/strongconflicts.cmx -o algo/algo.cmx  ; then  rm -f algo/algo.mli  ; else  rm -f algo/algo.mli  ; exit 1; fi
File "algo/algo.cmx", line 1:
Error: The implementation (obtained by packing)
       does not match the interface algo/algo.mli:
       ...
       In module Defaultgraphs.SyntacticDependencyGraph.G:
       Type declarations do not match:
          type t =
             Graph.Imperative.Digraph.ConcreteLabeled(Defaultgraphs.SyntacticDependencyGraph.PkgV)(Defaultgraphs.SyntacticDependencyGraph.PkgE).t
       is not included in
          type t = Graph.Imperative.Digraph.ConcreteLabeled(PkgV)(PkgE).t
Command exited with code 1.

```

Not creating a temporary, empty .mli worked better...