### PR TITLE
make sure that -just-plugin always stops after the plugin-build phase

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,9 @@ NEXT_RELEASE:
 - #127: install ocamlbuild's man pages, missing since 4.02
   (Gabriel Scherer)
 
+- #130: make sure that -just-plugin always stops after the plugin-build phase
+  (Gabriel Scherer, report by whitequark)
+
 - #132: add a rule producing .cmxs from .mllib files.
   Previously, .mllib files would only produce .cm{x,}a files, and .cmxs were
   only produced by a separate (and in most cases redundant) .mldylib file.

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ PACK_CMO= $(addprefix src/,\
   ocaml_compiler.cmo \
   ocaml_tools.cmo \
   ocaml_specific.cmo \
-  plugin.cmo \
   exit_codes.cmo \
+  plugin.cmo \
   hooks.cmo \
   main.cmo \
   )

--- a/testsuite/internal.ml
+++ b/testsuite/internal.ml
@@ -380,6 +380,15 @@ CAMLprim value hello_world(value unit)
   ]
   ~targets:("libtest.a", []) ();;
 
+let () = test "JustNoPlugin"
+    ~description:"(ocamlbuild -just-plugin) should do nothing when no plugin is there"
+    ~options:[`no_ocamlfind; `just_plugin]
+    ~tree:[T.f "test.ml" ~content:{|print_endline "Hellow World"|};]
+    (* we check that the target is *not* built *)
+    ~matching:[_build [M.Not (M.f "test.cmo")]]
+    ~targets:("test.cmo", [])
+    ();;
+
 let () = test "MldylibOverridesMllib"
   ~description:"Check that the rule producing a cmxs from a .mllib only \
                 triggers if there is no .mldylib"


### PR DESCRIPTION
Previously `-just-plugin` would only be checked at the end of plugin
build, and plugin build would only run if there is a plugin. This
means that `-just-plugin` would be ignored if there was no
`myocamlbuild.ml`: the command `ocamlbuild -just-plugin foo.byte`
 would build the target or not depending on whether a plugin source
was present.

This issue was reported by @whitequark in dbuenzli/topkg#87.