### PR TITLE
Remove warning 3.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OCAMLLEX  ?= ocamllex
 endif
 
 CP        ?= cp
-COMPFLAGS ?= -w L -w R -w Z -warn-error +a -I src -I +unix -safe-string -bin-annot
+COMPFLAGS ?= -w L -w R -w Z -I src -I +unix -safe-string -bin-annot
 LINKFLAGS ?= -I +unix -I src
 
 PACK_CMO= $(addprefix src/,\

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OCAMLLEX  ?= ocamllex
 endif
 
 CP        ?= cp
-COMPFLAGS ?= -w L -w R -w Z -I src -I +unix -safe-string -bin-annot
+COMPFLAGS ?= -w L -w R -w Z -warn-error +a -I src -I +unix -safe-string -bin-annot
 LINKFLAGS ?= -I +unix -I src
 
 PACK_CMO= $(addprefix src/,\

--- a/src/display.ml
+++ b/src/display.ml
@@ -298,10 +298,10 @@ let update_tagline_from_tags ds =
         done
     | (tag, c) :: rest ->
         if Tags.mem tag tags then
-          Bytes.set tagline i (Char.uppercase c)
+          Bytes.set tagline i (Char.uppercase_ascii c)
         else
           if Tags.mem tag ds.ds_seen_tags then
-            Bytes.set tagline i (Char.lowercase c)
+            Bytes.set tagline i (Char.lowercase_ascii c)
           else
             Bytes.set tagline i '-';
         loop (i + 1) rest

--- a/src/loc.ml
+++ b/src/loc.ml
@@ -20,7 +20,7 @@ let print_loc ppf (source, start, end_) =
     if one_or_two then fprintf ppf " %d" start_num
     else fprintf ppf "s %d-%d" start_num end_num in
   fprintf ppf "%s %S, line%a, character%a:@."
-    (String.capitalize source)
+    (String.capitalize_ascii source)
     (file start)
     (print (line start = line end_))
       (line start, line end_)

--- a/src/ocaml_specific.ml
+++ b/src/ocaml_specific.ml
@@ -947,17 +947,17 @@ flag ["ocaml"; "ocamllex"; "quiet"] (A"-q");;
 
 let ocaml_warn_flag c =
   flag ~deprecated:true
-    ["ocaml"; "compile"; sprintf "warn_%c" (Char.uppercase c)]
-    (S[A"-w"; A (sprintf "%c" (Char.uppercase c))]);
+    ["ocaml"; "compile"; sprintf "warn_%c" (Char.uppercase_ascii c)]
+    (S[A"-w"; A (sprintf "%c" (Char.uppercase_ascii c))]);
   flag ~deprecated:true
-    ["ocaml"; "compile"; sprintf "warn_error_%c" (Char.uppercase c)]
-    (S[A"-warn-error"; A (sprintf "%c" (Char.uppercase c))]);
+    ["ocaml"; "compile"; sprintf "warn_error_%c" (Char.uppercase_ascii c)]
+    (S[A"-warn-error"; A (sprintf "%c" (Char.uppercase_ascii c))]);
   flag ~deprecated:true
-    ["ocaml"; "compile"; sprintf "warn_%c" (Char.lowercase c)]
-    (S[A"-w"; A (sprintf "%c" (Char.lowercase c))]);
+    ["ocaml"; "compile"; sprintf "warn_%c" (Char.lowercase_ascii c)]
+    (S[A"-w"; A (sprintf "%c" (Char.lowercase_ascii c))]);
   flag ~deprecated:true
-    ["ocaml"; "compile"; sprintf "warn_error_%c" (Char.lowercase c)]
-    (S[A"-warn-error"; A (sprintf "%c" (Char.lowercase c))]);;
+    ["ocaml"; "compile"; sprintf "warn_error_%c" (Char.lowercase_ascii c)]
+    (S[A"-warn-error"; A (sprintf "%c" (Char.lowercase_ascii c))]);;
 
 List.iter ocaml_warn_flag ['A'; 'C'; 'D'; 'E'; 'F'; 'K'; 'L'; 'M'; 'P'; 'R'; 'S'; 'U'; 'V'; 'X'; 'Y'; 'Z'];;
 

--- a/src/ocaml_utils.ml
+++ b/src/ocaml_utils.ml
@@ -34,14 +34,14 @@ end
 let flag_and_dep = Flags.flag_and_dep
 let pflag_and_dep = Flags.pflag_and_dep ?doc_param:None
 
-let module_name_of_filename f = String.capitalize (Pathname.remove_extensions f)
+let module_name_of_filename f = String.capitalize_ascii (Pathname.remove_extensions f)
 let module_name_of_pathname x =
   module_name_of_filename (Pathname.to_string (Pathname.basename x))
 
 let ignore_stdlib x =
   if !Options.nostdlib then false
   else
-    let x' = !*stdlib_dir/((String.uncapitalize x)-.-"cmi") in
+    let x' = !*stdlib_dir/((String.uncapitalize_ascii x)-.-"cmi") in
     Pathname.exists x'
 
 let non_dependencies = ref []
@@ -63,8 +63,8 @@ let expand_module =
   memo3 (fun include_dirs module_name exts ->
     let dirname = Pathname.dirname module_name in
     let basename = Pathname.basename module_name in
-    let module_name_cap = dirname/(String.capitalize basename) in
-    let module_name_uncap = dirname/(String.uncapitalize basename) in
+    let module_name_cap = dirname/(String.capitalize_ascii basename) in
+    let module_name_uncap = dirname/(String.uncapitalize_ascii basename) in
     List.fold_right begin fun include_dir ->
       List.fold_right begin fun ext acc ->
         include_dir/(module_name_uncap-.-ext) ::

--- a/src/options.ml
+++ b/src/options.ml
@@ -77,7 +77,7 @@ let mk_virtual_solvers =
   List.iter begin fun cmd ->
     let solver () =
       A (find_tool cmd)
-    in Command.setup_virtual_command_solver (String.uppercase cmd) solver
+    in Command.setup_virtual_command_solver (String.uppercase_ascii cmd) solver
   end
 
 let () =
@@ -369,7 +369,7 @@ let init () =
   dir_reorder my_include_dirs include_dirs;
   dir_reorder my_exclude_dirs exclude_dirs;
 
-  ignore_list := List.map String.capitalize !ignore_list
+  ignore_list := List.map String.capitalize_ascii !ignore_list
 ;;
 
 (* The current heuristic: we know we are in an ocamlbuild project if


### PR DESCRIPTION
This removes the warning 3 from ocamlbuild by using the correct upper/lowercase functions. Also the warn on error for all warnings is added. All places were the uppercase/lowercase functions were used were either for internal use or for module names which only are allowed to use a-z,A-Z,0-9 and _.