### PR TITLE
Precise scale in verbose option description

### DIFF
--- a/src/options.ml
+++ b/src/options.ml
@@ -179,7 +179,7 @@ let spec = ref (
    "-vnum", Unit print_vnum, " Display the version number";
    "--vnum", Unit print_vnum, " same as -vnum";
    "-quiet", Unit (fun () -> Log.level := 0), " Make as quiet as possible";
-   "-verbose", Int (fun i -> Log.classic_display := true; Log.level := i + 2), "<level> Set the verbosity level";
+   "-verbose", Int (fun i -> Log.classic_display := true; Log.level := i + 2), "<level> Set the verbosity level on a scale from 0 to 8 (included)";
    "-documentation", Set show_documentation, " Show rules and flags";
    "-log", Set_string log_file_internal, "<file> Set log file";
    "-no-log", Unit (fun () -> log_file_internal := ""), " No log file";


### PR DESCRIPTION
This short commit precises the scale of the verbosity level in the corresponding option description.
The exposed scale {0,…,8} (aka {2,…,10} once mapped to log level)  is a strict subset of the real scale {-4,…,8} used by the logger. However, I thought that exposing the negative part of the scale (which has non-trivial interaction with other options) was not worth the added complexity. 