### PR TITLE
Defer to the compiler in choosing how to build a shared library

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,10 @@ of the usual "- ".
 NEXT_RELEASE:
 -------------
 
+- #124: do not explicitly pass -shared when building shared libraries;
+  let the compiler decide what to build.
+  (whitequark)
+
 0.10.0 (25 Dec 2016):
 ---------------------
 

--- a/src/ocaml_specific.ml
+++ b/src/ocaml_specific.ml
@@ -232,13 +232,13 @@ rule "ocaml: cmo* -> byte.c"
   ~dep:"%.cmo"
   (Ocaml_compiler.byte_output_obj "%.cmo" x_byte_c);;
 
-rule "ocaml: cmo* -> byte.(so|dll|dylib)"
+rule "ocaml: cmo* -> byte.(so|dll)"
   ~prod:x_byte_so
   ~dep:"%.cmo"
-  ~doc:"The foo.byte.so target, or foo.byte.dll under Windows, \
-  or foo.byte.dylib under Mac OS X will produce a shared library file
-  by passing the -output-obj and -cclib -shared options \
-  to the OCaml compiler. See also foo.native.{so,dll,dylib}."
+  ~doc:"The foo.byte.so target, or foo.byte.dll under Windows \
+  and macOS will produce a shared library file by passing \
+  the -output-obj option to the OCaml compiler. \
+  See also foo.native.{so,dll}."
   (Ocaml_compiler.byte_output_shared "%.cmo" x_byte_so);;
 
 rule "ocaml: p.cmx* & p.o* -> p.native"
@@ -259,7 +259,7 @@ rule "ocaml: cmx* & o* -> native.(o|obj)"
   ~deps:["%.cmx"; x_o]
   (Ocaml_compiler.native_output_obj "%.cmx" x_native_o);;
 
-rule "ocaml: cmx* & o* -> native.(so|dll|dylib)"
+rule "ocaml: cmx* & o* -> native.(so|dll)"
   ~prod:x_native_so
   ~deps:["%.cmx"; x_o]
   (Ocaml_compiler.native_output_shared "%.cmx" x_native_so);;
@@ -848,7 +848,6 @@ flag ["c";     "debug"; "compile"] (A "-g");
 flag ["c";     "debug"; "link"] (A "-g");
 flag ["ocaml"; "link"; "native"; "output_obj"] (A"-output-obj");;
 flag ["ocaml"; "link"; "byte"; "output_obj"] (A"-output-obj");;
-flag ["ocaml"; "link"; "output_shared"] & (S[A"-cclib"; A"-shared"]);;
 flag ["ocaml"; "dtypes"; "compile"] (A "-dtypes");;
 flag ["ocaml"; "annot"; "compile"] (A "-annot");;
 flag ["ocaml"; "annot"; "pack"] (A "-annot");;


### PR DESCRIPTION
This commit performs two changes:
  * When building a shared library through -output-obj, ocamlbuild
    will no longer try and second-guess the compiler with regards
    to how to build it, by passing a -cclib -shared flag.
    This was harmless on Windows and *nix, but produced errors
    on macOS; see #124 and ocaml/ocaml#988.
  * The documentation no longer mentions the .dylib extension,
    which was not used for anything by ocaml or ocamlbuild for
    a very long time (forever).

Due to ocaml/ocaml#988, there is a subtle difference in behavior
when ocamlbuild is used on 4.04 and previous versions versus
4.05:
  * On 4.04 and earlier versions, it was not possible to build
    an x.{byte,native}.so on macOS as the linker flags conflicted.
    After this commit, this is possible and produces a Mach-O
    bundle.
  * On 4.05 and later versions, passing -cclib -shared is a no-op.

Since it is not unusual that x.{byte,native}.so is explicitly loaded
dynamically, I have decided to remove the -cclib -shared flag
instead of leaving it as a no-op, to let people using new ocamlbuild
with old OCaml compilers take advantage of that.

The output_shared tag is left for backwards compatibility with
myocamlbuild.ml code that adds flags through it.