### PR TITLE
Fix linking of .cmxs targets that link stubs.

### DIFF
--- a/src/ocaml_specific.ml
+++ b/src/ocaml_specific.ml
@@ -393,12 +393,12 @@ rule "ocaml: cmx & o -> cmxa & a"
 
 rule "ocaml: p.cmxa & p.a -> p.cmxs & p.so"
   ~prods:["%.p.cmxs"; x_p_dll]
-  ~deps:["%.p.cmxa"; x_p_a]
+  ~deps:["%.p.cmxa"]
   (Ocaml_compiler.native_shared_library_link ~tags:["profile";"linkall"] "%.p.cmxa" "%.p.cmxs");;
 
-rule "ocaml: cmxa & a -> cmxs & so"
+rule "ocaml: cmxa -> cmxs & so"
   ~prods:["%.cmxs"; x_dll]
-  ~deps:["%.cmxa"; x_a]
+  ~deps:["%.cmxa"]
   ~doc:"This rule allows to build a .cmxs from a .cmxa, to avoid having \
         to duplicate a .mllib file into a .mldylib."
   (Ocaml_compiler.native_shared_library_link ~tags:["linkall"] "%.cmxa" "%.cmxs");;


### PR DESCRIPTION
See the individual commit messages. In general, this addresses the reasons [0.10.1 got reverted](https://github.com/ocaml/opam-repository/pull/8157), and also fixes several glaring omissions in the build system and test suite that made writing the test for the fix quite obnoxious.