### PR TITLE
Test our external dependencies on Travis as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ install:
   - sudo apt-get install -qq opam
   - export OPAMYES=1
   - opam init --compiler=${OCAML_VERSION}
-  - opam install ocamlfind
+  - opam install ocamlfind camlp4 menhir
+  # The command above has ocamlbuild as a transitive build dependency.
+  # Remove it now, so as not to accidentally link to the system ocamlbuildlib.
+  - opam remove ocamlbuild
 script:
   - eval `opam config env`
   # First, run our own testsuite. Do this *before* any ocamlbuild is installed globally,


### PR DESCRIPTION
The commit 48a3e14f is causing a spurious failure because of the way
opam sets up ocamlfind path. The opam PPA uses OCaml 4.02, which
installs a system camlp4. This system camlp4 is not afterwards used
by any opam package, but it is still present in the ocamlfind path,
which causes the subsequent error:
  Fatal error: OCaml and preprocessor have incompatible versions

It seems futile to try and fix this error in ocamlbuild testsuite
when simply installing our test dependencies will also do that,
and also get us more tests, so do that.