### PR TITLE
install license, changes, readme in opam's docdir for `odig`

### DIFF
--- a/Changes
+++ b/Changes
@@ -85,6 +85,9 @@ detailed changelog below for details.
 - #172-175, #177: setting up Continuous Infrastructure (CI) testsuite checks
   (whitequark)
 
+- #202: install license, changes and readme in opam's docdir for `odig`
+  (Gabriel Scherer, request and review by Daniel Bünzli)
+
 - "noautolink" tag for ocaml{c,opt}
   (Gabriel Scherer)
 

--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,7 @@ install-lib-basics:
 	$(CP) META src/signatures.mli $(INSTALL_LIBDIR)/ocamlbuild
 
 install-lib-basics-opam:
+	echo '  "opam"' >> ocamlbuild.install
 	echo '  "META"' >> ocamlbuild.install
 	echo '  "src/signatures.mli" {"signatures.mli"}' >> ocamlbuild.install
 
@@ -334,6 +335,13 @@ install-man-opam:
 	echo ']' >> ocamlbuild.install
 	echo >> ocamlbuild.install
 
+install-doc-opam:
+	echo 'docdir: [' >> ocamlbuild.install
+	echo '  "LICENSE"' >> ocamlbuild.install
+	echo '  "Changes"' >> ocamlbuild.install
+	echo '  "Readme.md"' >> ocamlbuild.install
+	echo ']' >> ocamlbuild.install
+
 uninstall-bin:
 	rm $(BINDIR)/ocamlbuild
 	rm $(BINDIR)/ocamlbuild.byte
@@ -385,6 +393,7 @@ ocamlbuild.install:
 	$(MAKE) install-bin-opam
 	$(MAKE) install-lib-opam
 	$(MAKE) install-man-opam
+	$(MAKE) install-doc-opam
 
 check-if-preinstalled:
 ifeq ($(CHECK_IF_PREINSTALLED), true)


### PR DESCRIPTION
This is intended to fix #179, but I plan to iterate based on @dbuenzli's feedback as I'm not completely sure what the expected format is. The current PR generates the following in `.install`:

```
docdir: [
  "LICENSE"
  "Changes"
  "Readme.md"
]
```

is this ok? Do you need a more canonical result filename for `Readme.md`?