### PR TITLE
Provide `-project` command line option to avoid recursive traversal hint

### DIFF
--- a/src/ocaml_compiler.ml
+++ b/src/ocaml_compiler.ml
@@ -124,7 +124,7 @@ let prepare_compile build ml =
         dprintf 3
           "Warning: Failed to build the module %s requested by ocamldep."
           name;
-        if not (!Options.recursive || Options.ocamlbuild_project_heuristic ())
+        if not (!Options.recursive || !Options.project || Options.ocamlbuild_project_heuristic ())
         then Log.at_failure ~name:"a module failed to build,
            while recursive traversal was disabled by fragile heuristic;
            hint that having a _tags or myocamlbuild.ml would maybe solve

--- a/src/options.ml
+++ b/src/options.ml
@@ -107,6 +107,7 @@ let program_to_execute = ref false
 let must_clean = ref false
 let show_documentation = ref false
 let recursive = ref false
+let project = ref false
 let ext_lib = ref Ocamlbuild_config.a
 let ext_obj = ref Ocamlbuild_config.o
 let ext_dll =
@@ -191,6 +192,7 @@ let spec = ref (
    "-no-log", Unit (fun () -> log_file_internal := ""), " No log file";
    "-clean", Set must_clean, " Remove build directory and other files, then exit";
    "-r", Set recursive, " Traverse directories by default (true: traverse)";
+   "-project", Set project, " Is a project (disable heuristics)";
 
    "-I", String (add_to' my_include_dirs), "<path> Add to include directories";
    "-Is", String (add_to my_include_dirs), "<path,...> (same as above, but accepts a (comma or blank)-separated list)";

--- a/src/options.mli
+++ b/src/options.mli
@@ -24,7 +24,7 @@ include Signatures.OPTIONS with type command_spec = Command.spec
 val plugin_tags : string list ref
 
 (* Returns 'true' if we heuristically infer that we are run from an
-   ocamlbuild projet (either _tags or myocamlbuild.ml are present).
+   ocamlbuild project (either _tags or myocamlbuild.ml are present).
 
    This information is used to decide whether to enable recursive
    traversal of subdirectories by default.

--- a/src/signatures.mli
+++ b/src/signatures.mli
@@ -407,6 +407,7 @@ module type OPTIONS = sig
   val use_menhir : bool ref
   val show_documentation : bool ref
   val recursive : bool ref
+  val project : bool ref
   val use_ocamlfind : bool ref
   val plugin_use_ocamlfind : bool ref
 


### PR DESCRIPTION
The current heuristic (Options.ocamlbuild_project_heuristic) checks for either
`_tags` or `myocamlbuild.ml` to be present, or "-recursive" being passed to
ocamlbuild.  This works fine for many applications, but e.g. for mirage
unikernels it does not (they are in a flat directory, subdirectories may be
present containing data which should not be traversed).

At the moment, mirage creates an empty `myocamlbuild.ml` before calling
ocamlbuild to avoid this (for MirageOS users misleading) hint.

(Suggestions for the command line option are welcome.)  The bits of mirage in question are at https://github.com/mirage/mirage/blob/279f365d8a031ccd30cb593657396f916d09a4ba/lib/mirage.ml#L1617-L1627