### PR TITLE
Don't hard-code object file extension...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ src/ocamlbuild_pack.cmx: $(PACK_CMX)
 	mkdir -p tmp
 	$(OCAMLOPT) -pack $^ -o tmp/ocamlbuild_pack.cmx
 	mv tmp/ocamlbuild_pack.cmx src/ocamlbuild_pack.cmx
-	mv tmp/ocamlbuild_pack.o src/ocamlbuild_pack.o
+	mv tmp/ocamlbuild_pack$(EXT_OBJ) src/ocamlbuild_pack$(EXT_OBJ)
 
 # The lexers
 


### PR DESCRIPTION
https://github.com/ocaml/ocamlbuild/pull/172/commits/691ccdc355fd1a887fffdfbf518b29ee70e8eaf6#diff-b67911656ef5d18c4ae36cb6741b7965R161 in #172 breaks MSVC. One-line fix...