### PR TITLE
extend cc/cclib/ccopt to apply to OCaml files as well

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,10 @@ NEXT_RELEASE:
   ocamlopt options.
   (Jeremy Yallop)
 
+- #237: extend cc/ccopt/cclib flags to apply to "ocaml" compilation as well,
+  as tweaking the C linker can be required for pure-OCaml projects -- see #236
+  (Gabriel Scherer, report by Nathan Rebours)
+
 0.11.0 (5 Mar 2017):
 --------------------
 

--- a/src/ocaml_specific.ml
+++ b/src/ocaml_specific.ml
@@ -1000,13 +1000,14 @@ pflag ["ocaml"; "doc"; "man"] "man_section"
 ocaml_lib "ocamlbuildlib";;
 ocaml_lib "ocamlbuildlightlib";;
 
-pflag ["c"; "compile"] "cc" (fun param -> S [A "-cc"; A param]);;
-pflag ["c"; "link"] "cc" (fun param -> S [A "-cc"; A param]);;
-
-pflag ["c"; "compile"] "ccopt" (fun param -> S [A "-ccopt"; A param]);;
-pflag ["c"; "link"] "ccopt" (fun param -> S [A "-ccopt"; A param]);;
-
-pflag ["c"; "compile"] "cclib" (fun param -> S [A "-cclib"; A param]);;
-pflag ["c"; "link"] "cclib" (fun param -> S [A "-cclib"; A param]);;
+begin
+  let ccflag ~lang ~phase ~flag =
+    pflag [lang; phase] flag (fun param -> S [A ("-"^flag); A param])
+  in
+  ["c"; "ocaml"] |> List.iter (fun lang ->
+  ["compile"; "link"] |> List.iter (fun phase ->
+  ["cc"; "ccopt"; "cclib"] |> List.iter (fun flag ->
+    ccflag ~lang ~phase ~flag)))
+end;;
 
 end in ()


### PR DESCRIPTION
The #236 issue demonstrates that they are required for pure OCaml
project.

closes #236.

I did not know how to write a reliable regression test for this
change.