### PR TITLE
examples: add example of working with dependent projects

### DIFF
--- a/examples/07-dependent-projects/Makefile
+++ b/examples/07-dependent-projects/Makefile
@@ -1,0 +1,33 @@
+#
+# Pure OCaml, project depends on library code from a local project
+#
+# For more details, see:
+# https://ocaml.org/learn/tutorials/ocamlbuild/Working_on_dependent_projects_with_ocamlbuild.html
+#
+
+# - The -I flag introduces sub-directories
+
+.PHONY: all clean byte native profile debug test
+
+OCB_FLAGS = -I src -I libdemo
+OCB = ocamlbuild $(OCB_FLAGS)
+
+all: native byte
+
+clean:
+	$(OCB) -clean
+
+native:
+	$(OCB) main.native
+
+byte:
+	$(OCB) main.byte
+
+profile:
+	$(OCB) -tag profile main.native
+
+debug:
+	$(OCB) -tag debug main.byte
+
+test: native
+	./main.native groucho harpo chico

--- a/examples/07-dependent-projects/libdemo
+++ b/examples/07-dependent-projects/libdemo
@@ -1,0 +1,1 @@
+../04-library/libdemo

--- a/examples/07-dependent-projects/src/main.ml
+++ b/examples/07-dependent-projects/src/main.ml
@@ -1,0 +1,9 @@
+let main () =
+  let argv = Array.to_list Sys.argv in
+  let args = List.tl argv in
+  let this = List.hd argv in
+  match args with
+  | [] -> Printf.eprintf "usage: %s [WORD]..." this; exit 1
+  | _  -> Printf.eprintf "%s\n" (Util.join args)
+
+let () = main ()

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -91,6 +91,10 @@ We maintain a few self-contained examples of projects using various OCamlbuild f
 
 | link:../examples/06-ocamldoc[06-ocamldoc]
 | A simple example illustrating the use of OCamldoc to generate documentation as html, TeX, man-pages and graphviz files. See <<Sec_Archives_documentation>> for more details.
+
+| link:../examples/07-dependent-projects[07-dependent-projects]
+| A simple example demonstrating the use of symbolic links to include library code from another local project.
+ See https://ocaml.org/learn/tutorials/ocamlbuild/Working_on_dependent_projects_with_ocamlbuild.html[here] for more details.
 |===
 
 NOTE: There are many ways to integrate OCamlbuild in your project.


### PR DESCRIPTION
I found the following example on `ocaml.org` useful when I needed a quick and easy way include code from another local subproject without the added overhead of using an `opam`-based workflow:
https://ocaml.org/learn/tutorials/ocamlbuild/Working_on_dependent_projects_with_ocamlbuild.html

This PR adds a slightly simpler example of the same technique to the `examples` directory , using the `04-library/libdemo` modules as the library code on which the new example project depends.  It also amends the _Examples_ section of the manual to include the new example.