### PR TITLE
add _opam to the default list of ignored directories

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,6 +25,10 @@ NEXT_RELEASE:
   as tweaking the C linker can be required for pure-OCaml projects -- see #236
   (Gabriel Scherer, report by Nathan Rebours)
 
+- #257, #259: add `_opam` to the list of directories ignored by default;
+  it is used for package-local opam switches
+  (Gabriel Scherer, request by Edwin Török)
+
 0.11.0 (5 Mar 2017):
 --------------------
 

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -364,7 +364,7 @@ That means that if you want to add "foo/bar" (and its files) as part of the sour
 "foo/baz": -traverse
 ----
 
-If the option `-r` (for _recursive_) is passed, then all subdirectories (recursively) are considered part of the source directories by default, except the build directory and directories that look like version-control information (`.svn`, `.bzr`, `.hg`, `.git`, `_darcs`).
+If the option `-r` (for _recursive_) is passed, then all subdirectories (recursively) are considered part of the source directories by default, except the build directory and directories that look like version-control information (`.svn`, `.bzr`, `.hg`, `.git`, `_darcs`) and `_opam`, used for project-local opam switches.
 
 This option is enabled by default _if_ the root directory looks like an OCamlbuild project: either a `myocamlbuild.ml` or a `_tags` file is present.
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -96,7 +96,7 @@ let proceed () =
 <**/*.cmi>: ocaml, byte, native
 <**/*.cmx>: ocaml, native
 <**/*.mly>: infer
-<**/.svn>|"CVS"|".bzr"|".hg"|".git"|"_darcs"|"node_modules": -traverse
+<**/.svn>|"CVS"|".bzr"|".hg"|".git"|"_darcs"|"_opam"|"node_modules": -traverse
 |};
 
   List.iter

--- a/src/options.ml
+++ b/src/options.ml
@@ -136,6 +136,7 @@ let log_file_internal = ref "_log"
 let my_include_dirs = ref [[Filename.current_dir_name]]
 let my_exclude_dirs = ref [
   [".svn"; "CVS"; ".bzr"; ".hg"; ".git"; "_darcs";
+   "_opam";
    "node_modules"]
 ]
 


### PR DESCRIPTION
Fixes #257

_opam is used for package-local switches, and it stores build output
files which are flagged by the hygiene checker.