### PR TITLE
add ppopt(arg) and ppxopt(package,arg) when -use-ocamlfind

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,10 @@ of the usual "- ".
 NEXT_RELEASE:
 -------------
 
+- #45, #190: add ppopt(arg) and ppxopt(package,arg) when -use-ocamlfind
+  (Gabriel Scherer, review by whitequark,
+   request by Gabriel Scherer, Gabriel Radanne and Pavel Argentov)
+
 0.12.0 (11 Nov 2017):
 ---------------------
 

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -309,6 +309,8 @@ Also note that the quoting, `-tag "syntax(camlp4o)"` instead of `-tag syntax(c
 
 If you use `-ppx` preprocessors, you can use the parametrized tag `ppx(...)` (`-tag "ppx(...)"`) to specify the preprocessor to use.
 
+Since ocamlbuild NEXT_RELASE, the tags `ppopt(option)` and `ppxopt(package,option)` are also supported -- if you have set `-use-ocamlfind`.
+
 // TODO: Improve title.
 [[Sec_Archives_documentation]]
 === Archives, documentation
@@ -761,6 +763,8 @@ Feel free to look at the implementation and link:../CONTRIBUTING.adoc[send a pat
 * `dontlink(pkgname)`
 * `predicate(foo)`
 * `syntax(bar)`
+* `ppopt(camlp4-option)` (since NEXT_RELEASE)
+* `ppxopt(package,option)` (since NEXT_RELEASE)
 
 ===== `ocamllex` tags
 

--- a/src/ocaml_specific.ml
+++ b/src/ocaml_specific.ml
@@ -693,13 +693,19 @@ let () =
       ["c"; "compile"];
     ] in
 
-    (* tags package(X), predicate(X) and syntax(X) *)
+    (* tags package(X), predicate(X) and syntax(X), ppopt(X), ppxopt(X) *)
     List.iter begin fun tags ->
       pflag tags "package" ~doc_param (fun pkg -> S [A "-package"; A pkg]);
       pflag tags "predicate" ~doc_param:"archive"
         (fun pkg -> S [A "-predicates"; A pkg]);
-      if List.mem "ocaml" tags then
-        pflag tags "syntax" ~doc_param:"camlp4o" (fun pkg -> S [A "-syntax"; A pkg])
+      if List.mem "ocaml" tags then begin
+        pflag tags "syntax" ~doc_param:"camlp4o"
+          (fun pkg -> S [A "-syntax"; A pkg]);
+        pflag tags "ppopt" ~doc_param:"pparg"
+          (fun arg -> S [A "-ppopt"; A arg]);
+        pflag tags "ppxopt" ~doc_param:"package,arg"
+          (fun arg -> S [A "-ppxopt"; A arg]);
+      end;
     end all_tags
   end else begin
     try

--- a/testsuite/external.ml
+++ b/testsuite/external.ml
@@ -43,4 +43,17 @@ let () = test "SubtoolOptions"
   ~targets:("parser.native",["parser.byte"])
   ();;
 
+let () = test "ppopt"
+  ~description:"Test the -ppopt option"
+  ~requirements:(package_exists "camlp4")
+  ~options:[`use_ocamlfind; `package "camlp4"; `syntax "camlp4o";
+            `tags ["ppopt(-no_quot)"];
+           ]
+  ~tree:[T.f "test.ml"
+           (* <<y>> looks like a camlp4 quotation and
+              will fail to compile unless '-no_quot' is passed *)
+           ~content:"let test (<<) (>>) x y z = x <<y>> z"]
+  ~targets:("test.cmo",[])
+  ();;
+
 run ~root:"_test_external";;


### PR DESCRIPTION
This is a pull request to fix #45, #190. I haven't thought very hard about the feature, and this is a minimalist implementation, that only passes the options unchanged to `ocamlfind`, and in particular is only available when `-use-ocamlfind` is used.