### PR TITLE
Remove two checks of Pathname.is_implicit

### DIFF
--- a/src/options.ml
+++ b/src/options.ml
@@ -383,17 +383,10 @@ let init () =
   reorder show_tags show_tags_internal;
   reorder plugin_tags plugin_tags_internal;
 
-  let check_dir dir =
-    if Filename.is_implicit dir then
-      sys_file_exists dir
-    else
-      failwith
-        (sprintf "Included or excluded directories must be implicit (not %S)" dir)
-  in
   let dir_reorder my dir =
     let d = !dir in
     reorder dir my;
-    dir := List.filter check_dir (!dir @ d)
+    dir := List.filter sys_file_exists (!dir @ d)
   in
   dir_reorder my_include_dirs include_dirs;
   dir_reorder my_exclude_dirs exclude_dirs;

--- a/src/resource.ml
+++ b/src/resource.ml
@@ -27,12 +27,9 @@ let print = Pathname.print
 let equal = (=)
 let compare = compare
 
-let in_source_dir p =
-  if Pathname.is_implicit p then Pathname.pwd/p else invalid_arg (Printf.sprintf "in_source_dir: %S" p)
+let in_source_dir p = Pathname.pwd/p
 
-let in_build_dir p =
-  if Pathname.is_relative p then p
-  else invalid_arg (Printf.sprintf "in_build_dir: %S" p)
+let in_build_dir p = p
 
 let clean_up_links entry =
   if not !Options.make_links then entry else


### PR DESCRIPTION
This is an attempt to address issue #152. I wanted to share this code and bump #152 in general. It'd be great to allow passing absolute paths to `-I` in ocamlbuild.

I have very little familiarity with ocamlbuild's source and absolutely no confidence that these are the right changes to make. These changes do allow a local ocamlbuild to build with relative include paths on my computer, and all the tests pass :paintbrush: 