### PR TITLE
Fix compilation for OCaml 4.08

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -14,12 +14,12 @@
 
 (* Original author: Berke Durak *)
 open My_std
+open Format
 open Log
 open Pathname.Operators
 open Command
 open Tools
 open Ocaml_specific
-open Format
 ;;
 
 exception Exit_build_error of string

--- a/src/main.ml
+++ b/src/main.ml
@@ -14,7 +14,6 @@
 
 (* Original author: Berke Durak *)
 open My_std
-open Format
 open Log
 open Pathname.Operators
 open Command

--- a/src/solver.ml
+++ b/src/solver.ml
@@ -14,8 +14,8 @@
 
 (* Original author: Nicolas Pouillard *)
 open My_std
-open Log
 open Format
+open Log
 open Outcome
 
 type backtrace =

--- a/src/solver.ml
+++ b/src/solver.ml
@@ -14,7 +14,6 @@
 
 (* Original author: Nicolas Pouillard *)
 open My_std
-open Format
 open Log
 open Outcome
 
@@ -31,6 +30,7 @@ let failed target backtrace =
   raise (Failed backtrace)
 
 let rec pp_repeat f (n, s) =
+  let open Format in
   if n > 0 then (pp_print_string f s; pp_repeat f (n - 1, s))
 
 (* Targets must be normalized pathnames.


### PR DESCRIPTION
The trunk version of OCaml has recently introduced
a function named `Format.dprintf`, but `ocamlbuild`
already had such a function -with a different signature-
in the `Log` module.

This PR tweaks the order of `open` statements so that
the function from `Format` does not shadow the one
from `Log`.
