### PR TITLE
Resolved conflict between Log.dprintf and Format.dprintf

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -14,7 +14,6 @@
 
 (* Original author: Berke Durak *)
 open My_std
-open Log
 open Pathname.Operators
 open Command
 open Tools
@@ -179,7 +178,7 @@ let proceed () =
   let entry = hygiene_entry in
   Hooks.call_hook Hooks.After_hygiene;
   Options.include_dirs := Pathname.current_dir_name :: List.rev !entry_include_dirs;
-  dprintf 3 "include directories are:@ %a" print_string_list !Options.include_dirs;
+  Log.dprintf 3 "include directories are:@ %a" print_string_list !Options.include_dirs;
   Options.entry := Some entry;
 
   Hooks.call_hook Hooks.Before_rules;
@@ -268,9 +267,9 @@ let proceed () =
         match List.rev cmds with
         | [] -> raise (Exit_usage "Using -- requires one target");
         | cmd :: rest ->
-          if rest <> [] then dprintf 0 "Warning: Using -- only run the last target";
+          if rest <> [] then Log.dprintf 0 "Warning: Using -- only run the last target";
           let cmd_spec = S [P cmd; atomize !Options.program_args] in
-          dprintf 3 "Running the user command:@ %a" Pathname.print cmd;
+          Log.dprintf 3 "Running the user command:@ %a" Pathname.print cmd;
           raise (Exit_with_code (call cmd_spec)) (* Exit with the exit code of the called command *)
       end
     else

--- a/src/solver.ml
+++ b/src/solver.ml
@@ -14,7 +14,6 @@
 
 (* Original author: Nicolas Pouillard *)
 open My_std
-open Log
 open Format
 open Outcome
 
@@ -40,7 +39,7 @@ let rec pp_repeat f (n, s) =
 let rec self depth on_the_go target =
   let rules = Rule.get_rules () in
   (* skip allocating fmt on a hot path *)
-  if is_logging 4 then dprintf 4 "==%a> %a" pp_repeat (depth, "==") Resource.print target;
+  if Log.is_logging 4 then Log.dprintf 4 "==%a> %a" pp_repeat (depth, "==") Resource.print target;
   begin match List.index_of target on_the_go with
     | None -> () (* good no cycle *)
     | Some n -> raise (Circular(target, fst (List.split_at (n+1) on_the_go)))
@@ -49,11 +48,11 @@ let rec self depth on_the_go target =
   let on_the_go = target :: on_the_go in
   match Resource.Cache.resource_state target with
   | Resource.Cache.Bbuilt ->
-      (if is_logging 5 then dprintf 5 "%a already built" Resource.print target)
+      (if Log.is_logging 5 then Log.dprintf 5 "%a already built" Resource.print target)
   | Resource.Cache.Bcannot_be_built ->
-      (if is_logging 5 then dprintf 5 "%a already failed" Resource.print target; failed target (Leaf target))
+      (if Log.is_logging 5 then Log.dprintf 5 "%a already failed" Resource.print target; failed target (Leaf target))
   | Resource.Cache.Bsuspension(s) ->
-      (if is_logging 5 then dprintf 5 "%a was suspended -> resuming" Resource.print target;
+      (if Log.is_logging 5 then Log.dprintf 5 "%a was suspended -> resuming" Resource.print target;
        Resource.Cache.resume_suspension s)
   | Resource.Cache.Bnot_built_yet ->
     if not (Pathname.is_relative target) && Pathname.exists target then
@@ -116,9 +115,9 @@ and self_firsts depth on_the_go rss =
   let count = List.length cmds in
   let job_debug = if !Command.jobs = 1 then 10 else 5 in
   (* skip allocating fmt on a hot path *)
-  if is_logging job_debug && count > 1 then dprintf job_debug ">>> PARALLEL: %d" count;
+  if Log.is_logging job_debug && count > 1 then Log.dprintf job_debug ">>> PARALLEL: %d" count;
   let opt_exn = Command.execute_many cmds in
-  if is_logging job_debug && count > 1 then dprintf job_debug "<<< PARALLEL";
+  if Log.is_logging job_debug && count > 1 then Log.dprintf job_debug "<<< PARALLEL";
   begin match opt_exn with
   | Some(res, exn) ->
       List.iter2 (fun res thunk -> if res then thunk ()) res thunks;


### PR DESCRIPTION
Ocaml introduces [Format.dprintf](https://github.com/ocaml/ocaml/pull/1959) which conflicts with Log.dprintf defined in ocamlbuild.

This PR ensures the correct dprintf is called.