### PR TITLE
Build with -strict-sequence

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,5 @@
 S src
 S bootstrap
 B .
+FLG -strict-sequence
+FLG -safe-string

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ OCAMLLEX  ?= ocamllex
 endif
 
 CP        ?= cp
-COMPFLAGS ?= -w L -w R -w Z -I src -I +unix -safe-string -bin-annot
+COMPFLAGS ?= -w L -w R -w Z -I src -I +unix -safe-string -bin-annot -strict-sequence
 LINKFLAGS ?= -I +unix -I src
 
 PACK_CMO= $(addprefix src/,\

--- a/src/signatures.mli
+++ b/src/signatures.mli
@@ -32,7 +32,7 @@ end
 
 module type LIST = sig
   (* Added functions *)
-  val print : (Format.formatter -> 'a -> 'b) -> Format.formatter -> 'a list -> unit
+  val print : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a list -> unit
   val filter_opt : ('a -> 'b option) -> 'a list -> 'b list
   val union : 'a list -> 'a list -> 'a list
   val ordered_unique : 'a list -> 'a list


### PR DESCRIPTION
This is a small fix that allows ocamlbuild to build when -strict-sequence is enabled.

I found this while trying to investigate the impact of enabling -strict-sequence by default (see https://github.com/ocaml/ocaml/pull/1971) -- ocamlbuild breaks, which transitively breaks a lot of packages.