### PR TITLE
change divisor and dividend

### DIFF
--- a/examples/05-lex-yacc/src/parser.mly
+++ b/examples/05-lex-yacc/src/parser.mly
@@ -23,6 +23,6 @@ expr
   | e1=expr PLUS  e2=expr   { e1 + e2 }
   | e1=expr MINUS e2=expr   { e1 - e2 }
   | e1=expr TIMES e2=expr   { e1 * e2 }
-  | e1=expr DIV   e2=expr   { e2 / e1 }
+  | e1=expr DIV   e2=expr   { e1 / e2 }
   | MINUS e = expr %prec UMINUS { - e }
   ;


### PR DESCRIPTION
In the example of 05-lex-yacc, when the DIV is used, the divisor and dividend was not correct.  The divisor is used as the dividend and the dividend is used as divisor.
So, `./main.native 1/2` outputs `2`, and `./main.native 2/1` outputs `0`.

And, I change the divisor and dividend.