### PR TITLE
Fix race conditions when invoking `ocamlbuild` in parallel from a makefile

### DIFF
--- a/ocamlbuild.opam
+++ b/ocamlbuild.opam
@@ -7,7 +7,7 @@ license: "LGPL-2 with OCaml linking exception"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
 synopsis:
-  "OCamlbuild is a build system with builtin rules to easily build most OCaml projects."
+  "OCamlbuild is a build system with builtin rules to easily build most OCaml projects"
 
 build: [
   [

--- a/src/shell.ml
+++ b/src/shell.ml
@@ -70,10 +70,28 @@ let mkdir dir =
   reset_filesys_cache_for_file dir;
   (*Sys.mkdir dir (* MISSING in ocaml *) *)
   run ["mkdir"; dir] dir
-let try_mkdir dir = if not (sys_file_exists dir) then mkdir dir
+
+let try_mkdir dir =
+  if not (sys_file_exists dir)
+  then
+    (* We checked that the file does not exist, but we still
+       ignore failures due to the possibility of race conditions --
+       same as rm_f above.
+
+       Note: contrarily to the rm_f implementation which uses sys_remove directly,
+       the 'mkdir' implementation uses 'run', which will create noise in the log
+       and on display, especially in case of (ignored) failure: an error message
+       will be shown, but the call will still be considered a success.
+       Error messages only occur in racy scenarios that we don't support,
+       so this is probably okay. *)
+    try mkdir dir with _ -> ()
+
 let rec mkdir_p dir =
   if sys_file_exists dir then ()
-  else (mkdir_p (Filename.dirname dir); mkdir dir)
+  else begin
+      mkdir_p (Filename.dirname dir);
+      try_mkdir dir
+    end
 
 let cp_pf src dest =
   reset_filesys_cache_for_file dest;


### PR DESCRIPTION
I'm creating this PR to track my progress on fixing #300 and related race-conditions issue. The current reproduction testcase is as follows:

```
DIR=foo
FILE=code.ml

setup:
	mkdir -p $(DIR)
	echo "let x = 1" > $(DIR)/$(FILE)
	echo "run 'make -j all' to reproduce the failure'"

clean:
	ocamlbuild -clean

dist-clean: clean
	rm $(DIR)/$(FILE)
	rmdir $(DIR)

.PHONY: all test1 test2
all: test1 test2

test1:
	$(MAKE) _build/$(DIR)/$(FILE)

test2:
	$(MAKE) _build/$(DIR)/$(FILE)

_build/$(DIR)/$(FILE):
	ocamlbuild $(DIR)/$(FILE)
```

running `make setup; make -j all` exposes races in ocamlbuild's parallel accesses to the filesystem.

I don't think we will ever try to guarantee that concurrent ocamlbuild invocations work robustly, but we should at least fix the issues that users encounter in the wild, when reasonably possible.