### PR TITLE
Fix asciidoc error

### DIFF
--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -1359,7 +1359,7 @@ rule "ocaml C stubs: clib & (o|obj)* -> (a|lib) & (so|dll)"
 One cannot define a rule if there already exists a built-in rule of the same name.
 Directly including the rule `"ocaml dependencies ml"` used above in your plugin would result in a failure when loading the plugin:
 
-[source]
+[source,ocaml]
 ----
   Rule.Exit_rule_error("Rule.add_rule: already exists: (ocaml dependencies ml)").
 ----


### PR DESCRIPTION
With asciidoc 9.1.0 and pygments 2.10.0, I get this error from running `asciidoc manual/manual.adoc`:
```
asciidoc: ERROR: manual.adoc: line 1364: undefined filter attribute in command: pygmentize -f html -l {language} {src_numbered?-O linenos=table} {encoding?-O encoding={encoding}} {args=}
```
and line 1364 does not appear in the resulting HTML file.  With this commit, there are no errors and line 1364 appears in the output.
