### PR TITLE
Setup github actions for ocamlbuild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,81 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    # Prime the caches every Monday
+    - cron: 0 1 * * MON
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - "4.08"
+          - "4.09"
+          - "4.10"
+          - "4.11"
+          - "4.12"
+          - "4.13"
+          - "4.14"
+          - "5.0"
+          - "5.1"
+          - "5.2"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Set git to use LF
+        if: matrix.ocaml-compiler < 5.2
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+          git config --global core.ignorecase false
+
+      - name: Checkout tree
+        uses: actions/checkout@v4
+
+      - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
+        if: runner.os == 'Windows'
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-repositories: |
+            dra27: https://github.com/dra27/opam-repository.git#windows-5.0
+            default: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
+            opam: https://github.com/ocaml/opam-repository.git
+          dune-cache: true
+          opam-depext: ${{ !matrix.skip-test }}
+          opam-depext-flags: --with-test
+
+      - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
+        if: runner.os != 'Windows'
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          allow-prerelease-opam: true
+          dune-cache: true
+          opam-depext: ${{ !matrix.skip-test }}
+          opam-depext-flags: --with-test
+
+      - run: opam install . --with-test --deps-only
+
+      - run: VERBOSE=1 opam exec -- make test
+
+      - run: OCAMLBUILD=$(pwd)/ocamlbuild.native opam exec -- make -C bootstrap
+
+      - run: opam exec -- make distclean
+      - run: opam exec -- opam pin add -n -k path ocamlbuild .
+      - run: opam exec -- opam install -v ocamlbuild
+      - run: opam exec -- opam install -v mtime.1.0.0 # this tests topkg, with stub libraries
+      - run: opam exec -- opam install -v inotify.2.3 # this tests oasis, with stub libraries
+        if: matrix.ocaml-compiler < 5
+      - run: opam exec -- opam install -v cpuid.0.1.1 # this tests the ocb-stubblr plugin
+      - run: opam exec -- opam install -v shcaml.0.2.1 # this tests the cppo plugin
+        if: matrix.ocaml-compiler < 5

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ ocamlbuild.install
 Makefile.config
 
 /bootstrap/src
+/bootstrap/bin
+/bootstrap/plugin-lib
 /bootstrap/_build*
 
 /src/ocamlbuild_config.ml

--- a/Makefile
+++ b/Makefile
@@ -127,13 +127,13 @@ distclean:: clean
 # The executables
 
 ocamlbuild.byte: src/ocamlbuild_pack.cmo $(EXTRA_CMO) bin/ocamlbuild.cmo
-	$(OCAMLC) $(LINKFLAGS) -o $@ unix.cma $^
+	$(OCAMLC) $(LINKFLAGS) -o $@ -I +unix unix.cma $^
 
 ocamlbuildlight.byte: src/ocamlbuild_pack.cmo bin/ocamlbuildlight.cmo
 	$(OCAMLC) $(LINKFLAGS) -o $@ $^
 
 ocamlbuild.native: src/ocamlbuild_pack.cmx $(EXTRA_CMX) bin/ocamlbuild.cmx
-	$(OCAMLOPT) $(LINKFLAGS) -o $@ unix.cmxa $^
+	$(OCAMLOPT) $(LINKFLAGS) -o $@ -I +unix unix.cmxa $^
 
 # The libraries
 

--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,8 @@ plugin-lib/%.cmx: plugin-lib/%.ml
 
 clean::
 	rm -rf tmp/
-	rm -f src/*.cm* *.cm*
+	rm -f src/*.cm* *.cm* bin/*.cm* plugin-lib/*.cm*
+	rm -f src/*.o *.o bin/*.o plugin-lib/*.o plugin-lib/*.a
 ifdef EXT_OBJ
 	rm -f src/*$(EXT_OBJ) *$(EXT_OBJ)
 endif

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -11,11 +11,11 @@ setup:
 
 stage1: setup
 	@echo "BOOTSTRAP (1): building local ocamlbuild from '$(OCAMLBUILD)'"
-	@$(OCAMLBUILD) -build-dir _build_stage1 bootstrap.otarget
+	@$(OCAMLBUILD) -build-dir _build_stage1 bootstrap.otarget -no-plugin
 
 stage2: stage1
 	@echo "BOOTSTRAP (2): building local ocamlbuild from local ocamlbuild"
-	@_build_stage1/bin/ocamlbuild.native -build-dir _build_stage2 bootstrap.otarget
+	@_build_stage1/bin/ocamlbuild.native -build-dir _build_stage2 bootstrap.otarget -no-plugin
 
 clean:
 	@$(OCAMLBUILD) -clean

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -8,7 +8,6 @@ setup:
 	ln -sf ../src
 	ln -sf ../bin
 	ln -sf ../plugin-lib
-	mkdir -p dest
 
 stage1: setup
 	@echo "BOOTSTRAP (1): building local ocamlbuild from '$(OCAMLBUILD)'"
@@ -24,5 +23,4 @@ clean:
 	@$(OCAMLBUILD) -build-dir _build_stage2 -clean
 	@rm -f src bin plugin-lib
 	@rm -f dest/ocamlbuild_{stage1,stage2}.native
-	@rmdir dest
 

--- a/bootstrap/_tags
+++ b/bootstrap/_tags
@@ -20,6 +20,7 @@ true: debug
 "src/discard_printf.ml": rectypes
 "ocamlbuildlib.cma" or "ocamlbuildlightlib.cma": linkall
 <**/*.byte> or <**/*.native> or <**/*.top>: use_unix
+<plugin-lib/*.ml>: use_unix
 "ocamlbuildlight.byte": -use_unix, nopervasives
 <src/*.cmx>: for-pack(Ocamlbuild_pack)
 

--- a/ocamlbuild.opam
+++ b/ocamlbuild.opam
@@ -32,4 +32,6 @@ conflicts: [
 
 depends: [
   "ocaml" {>= "4.03"}
+  "ocamlfind" {with-test}
+  "menhirLib" {with-test}
 ]

--- a/src/ocaml_specific.ml
+++ b/src/ocaml_specific.ml
@@ -819,9 +819,9 @@ camlp4_flags' ["camlp4orr", S[A"camlp4of"; A"-parser"; A"reloaded"];
 
 flag ["ocaml"; "pp"; "camlp4:no_quot"] (A"-no_quot");;
 
-ocaml_lib ~extern:true "dynlink";;
-ocaml_lib ~extern:true "unix";;
-ocaml_lib ~extern:true "str";;
+ocaml_lib ~extern:true ~dir:"+dynlink" "dynlink";;
+ocaml_lib ~extern:true ~dir:"+unix" "unix";;
+ocaml_lib ~extern:true ~dir:"+str" "str";;
 ocaml_lib ~extern:true "bigarray";;
 ocaml_lib ~extern:true "nums";;
 ocaml_lib ~extern:true "dbm";;

--- a/src/plugin.ml
+++ b/src/plugin.ml
@@ -175,7 +175,7 @@ module Make(U:sig end) =
           let unix_lib =
             if use_ocamlfind_pkgs then `Package "unix"
             else if use_light_mode then `Nothing
-            else `Lib "unix" in
+            else `Lib ("+unix", "unix") in
 
           let ocamlbuild_lib =
             if use_ocamlfind_pkgs then `Package "ocamlbuild"
@@ -198,7 +198,7 @@ module Make(U:sig end) =
           let spec = function
             | `Nothing -> N
             | `Package pkg -> S[A "-package"; A pkg]
-            | `Lib lib -> P (lib -.- cma)
+            | `Lib (inc, lib) -> S[A "-I"; A inc; P (lib -.- cma)]
             | `Local_lib llib -> S [A "-I"; A dir; P (in_dir (llib -.- cma))]
             | `Local_mod lmod -> P (in_dir (lmod -.- cmo)) in
 

--- a/testsuite/external.ml
+++ b/testsuite/external.ml
@@ -31,7 +31,7 @@ let () = test "SubtoolOptions"
                 to the subtool invocation (PR#5763)"
   (* testing for the 'menhir' executable directly
      is too hard to do in a portable way; test the ocamlfind package instead *)
-  ~requirements:(package_exists "menhirLib")
+  ~requirements:(req_and (package_exists "menhirLib") (package_exists "camlp4"))
   ~options:[`use_ocamlfind; `use_menhir; `tags ["package(camlp4.fulllib)"]]
   ~tree:[T.f "parser.mly"
             ~content:"%{ %}

--- a/testsuite/external_test_header.ml
+++ b/testsuite/external_test_header.ml
@@ -5,3 +5,10 @@ let package_exists package =
   try ignore (package_directory package); Fullfilled
   with No_such_package _ ->
     Missing (Printf.sprintf "the ocamlfind package %s" package)
+
+let req_and a b =
+  match a, b with
+  | Fullfilled, Fullfilled -> Fullfilled
+  | Missing _ as x, Fullfilled
+  | Fullfilled, (Missing _ as x) -> x
+  | Missing a, Missing b -> Missing (Printf.sprintf "%s, %s" a b)

--- a/testsuite/findlibonly_test_header.ml
+++ b/testsuite/findlibonly_test_header.ml
@@ -1,4 +1,4 @@
-match Sys.command "ocamlfind ocamlc" with
+match Sys.command "ocamlfind ocamlc -version" with
     | 0 -> ()
     | _ ->
       prerr_endline "Having ocamlfind installed is a prerequisite \

--- a/testsuite/internal.ml
+++ b/testsuite/internal.ml
@@ -216,12 +216,20 @@ Error: This expression has type int but an expression was expected of type
          unit
        because it is in the left-hand side of a sequence
 Command exited with code 2."
-else
+else if Sys.ocaml_version < "5.2.0" then
 "File \"hello.ml\", line 1, characters 9-10:
 1 | let () = 1; ()
              ^
 Error: This expression has type int but an expression was expected of type
          unit
+       because it is in the left-hand side of a sequence
+Command exited with code 2."
+else
+"File \"hello.ml\", line 1, characters 9-10:
+1 | let () = 1; ()
+             ^
+Error: This expression has type \"int\" but an expression was expected of type
+         \"unit\"
        because it is in the left-hand side of a sequence
 Command exited with code 2."
 )

--- a/testsuite/internal_test_header.ml
+++ b/testsuite/internal_test_header.ml
@@ -1,3 +1,4 @@
+#directory "+unix";;
 #load "unix.cma";;
 
 #mod_use "../src/ocamlbuild_config.ml";;

--- a/testsuite/ocamlbuild_test.ml
+++ b/testsuite/ocamlbuild_test.ml
@@ -435,19 +435,51 @@ let print_colored header_color header name body_color body =
     (color_code header_color) header name
     (color_code body_color) body
 
+
 let run ~root =
   let dir = Sys.getcwd () in
   let root = dir ^ "/" ^ root in
   rm root;
   Unix.mkdir root 0o750;
+  let install_lib_dir = Filename.concat root "install-lib" in
+  let install_bin_dir = Filename.concat root "install-bin" in
 
   let test_tree = Filename.dirname (Sys.argv.(0)) in
   let test_tree = if test_tree = "." then Sys.getcwd () else test_tree in
   let build_tree = Filename.dirname test_tree in
-  let ocamlbuild = Filename.concat build_tree "ocamlbuild.byte" in
+
+  let copy l dest =
+    ignore(Sys.command (Printf.sprintf "mkdir -p %s" dest));
+    List.iter (fun f -> ignore(Sys.command (Printf.sprintf "cp %s/%s %s" build_tree f dest))) l
+  in
+  let ocamlbuild = Printf.sprintf "%s/ocamlbuild.byte" install_bin_dir in
+  copy
+    [ "plugin-lib/ocamlbuildlib.cma";
+      "plugin-lib/ocamlbuildlib.cmxa";
+      "plugin-lib/ocamlbuildlib.a";
+      "bin/ocamlbuild.cmo";
+      "bin/ocamlbuild.cmx";
+      "bin/ocamlbuild.o";
+      "src/ocamlbuild_pack.cmi";
+      "src/ocamlbuild_pack.cmx";
+      "src/ocamlbuild_pack.o";
+      "plugin-lib/ocamlbuild_plugin.cmi";
+      "plugin-lib/ocamlbuild_plugin.cmx";
+      "plugin-lib/ocamlbuild_plugin.o";
+      "plugin-lib/ocamlbuild_executor.cmi";
+      "plugin-lib/ocamlbuild_executor.cmx";
+      "plugin-lib/ocamlbuild_executor.o";
+      "plugin-lib/ocamlbuild_unix_plugin.cmi";
+      "plugin-lib/ocamlbuild_unix_plugin.cmx";
+      "plugin-lib/ocamlbuild_unix_plugin.o"]
+    install_lib_dir;
+  copy
+    [ "ocamlbuild.byte";
+      "ocamlbuild.native" ]
+    install_bin_dir;
   let testsuite_opts = [
-    (`install_bin_dir build_tree);
-    (`install_lib_dir (Filename.concat build_tree "src"));
+    (`install_bin_dir install_bin_dir);
+    (`install_lib_dir install_lib_dir);
   ] in
 
   let verbose =


### PR DESCRIPTION
This PR migrate the existing travis.yml CI instructions to github-actions.
Currently testing OCaml 4.08 .. 5.2

It also includes the following fixes.

- fix testsuite (see https://github.com/ocaml/ocamlbuild/issues/321)
- fix bootstrap
- fix tests for Ocaml 5.2

The underlying reason for the MR is to make is easier to test fixes for windows, such as https://github.com/ocaml/ocamlbuild/pull/323