### PR TITLE
Import fdopen patch for windows

### DIFF
--- a/META
+++ b/META
@@ -2,6 +2,5 @@
 requires = "unix"
 version = "NEXT_RELEASE"
 description = "ocamlbuild support library"
-directory= "^ocamlbuild"
 archive(byte) = "ocamlbuildlib.cma"
 archive(native) = "ocamlbuildlib.cmxa"

--- a/META
+++ b/META
@@ -2,5 +2,6 @@
 requires = "unix"
 version = "NEXT_RELEASE"
 description = "ocamlbuild support library"
+directory= "^ocamlbuild"
 archive(byte) = "ocamlbuildlib.cma"
 archive(native) = "ocamlbuildlib.cmxa"

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ distclean::
 	rm -f man/ocamlbuild.1
 
 man/options_man.byte: src/ocamlbuild_pack.cmo
-	$(OCAMLC) $^ -I src man/options_man.ml -o man/options_man.byte
+	$(OCAMLC) -I +unix unix.cma $^ -I src man/options_man.ml -o man/options_man.byte
 
 clean::
 	rm -f man/options_man.cm*

--- a/plugin-lib/ocamlbuild_executor.ml
+++ b/plugin-lib/ocamlbuild_executor.ml
@@ -75,7 +75,8 @@ let output_lines prefix oc buffer =
         try String.index_from u i '\n'
         with Not_found -> m
       in
-      output_line i j;
+      (let j = if j > 0 && u.[j-1] = '\r' then j - 1 else j in
+      output_line i j);
       loop (j + 1)
     else
       ()

--- a/src/command.ml
+++ b/src/command.ml
@@ -148,9 +148,10 @@ let rec string_of_command_spec_with_calls call_with_tags call_with_target resolv
   let self = string_of_command_spec_with_calls call_with_tags call_with_target resolve_virtuals in
   let b = Buffer.create 256 in
   (* The best way to prevent bash from switching to its windows-style
-   * quote-handling is to prepend an empty string before the command name. *)
+   * quote-handling is to prepend an empty string before the command name.
+   * space seems to work, too - and the ouput is nicer *)
   if Sys.os_type = "Win32" then
-    Buffer.add_string b "''";
+    Buffer.add_char b ' ';
   let first = ref true in
   let put_space () =
     if !first then
@@ -260,7 +261,7 @@ let flatten_commands quiet pretend cmd =
 
 let execute_many ?(quiet=false) ?(pretend=false) cmds =
   add_parallel_stat (List.length cmds);
-  let degraded = !*My_unix.is_degraded || Sys.os_type = "Win32" in
+  let degraded = !*My_unix.is_degraded in
   let jobs = !jobs in
   if jobs < 0 then invalid_arg "jobs < 0";
   let max_jobs = if jobs = 0 then None else Some jobs in

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -66,9 +66,6 @@ let run_and_parse lexer command =
     (fun command -> lexer & Lexing.from_string & run_and_read command)
     command
 
-let run_and_read command =
-  Printf.ksprintf run_and_read command
-
 let rec query name =
   try
     Hashtbl.find packages name
@@ -135,7 +132,8 @@ let before_space s =
   with Not_found -> s
 
 let list () =
-  List.map before_space (split_nl & run_and_read "%s list" ocamlfind)
+  let cmd = Shell.quote_filename_if_needed ocamlfind ^ " list" in
+  List.map before_space (split_nl & run_and_read cmd)
 
 (* The closure algorithm is easy because the dependencies are already closed
 and sorted for each package. We only have to make the union. We could also

--- a/src/main.ml
+++ b/src/main.ml
@@ -165,6 +165,9 @@ let proceed () =
               Tags.mem "traverse" tags
               || List.exists (Pathname.is_prefix path_name) !Options.include_dirs
               || List.exists (Pathname.is_prefix path_name) target_dirs)
+            && ((* beware: !Options.build_dir is an absolute directory *)
+              Pathname.normalize !Options.build_dir
+              <> Pathname.normalize (Pathname.pwd/path_name))
           end
         end
       end

--- a/src/my_std.mli
+++ b/src/my_std.mli
@@ -69,3 +69,6 @@ val lexbuf_of_string : ?name:string -> string -> Lexing.lexbuf
 
 val split_ocaml_version : (int * int * int * string) option
 (** (major, minor, patchlevel, rest) *)
+
+val windows_shell : string array Lazy.t
+val prep_windows_cmd : string -> string

--- a/src/options.ml
+++ b/src/options.ml
@@ -174,11 +174,24 @@ let set_build_dir s =
     build_dir := filename_concat (Sys.getcwd ()) s
   else
     build_dir := s
+
+let slashify =
+  if Sys.win32 then fun p -> String.map (function '\\' -> '/' | x -> x) p
+  else fun p ->p
+
+let sb () =
+  match Sys.os_type with
+  | "Win32" ->
+    (try set_binary_mode_out stdout true with _ -> ());
+  | _ -> ()
+
+
 let spec = ref (
     let print_version () =
+      sb ();
       Printf.printf "ocamlbuild %s\n%!" Ocamlbuild_config.version; raise Exit_OK
     in
-    let print_vnum () = print_endline Ocamlbuild_config.version; raise Exit_OK in
+    let print_vnum () = sb (); print_endline Ocamlbuild_config.version; raise Exit_OK in
   Arg.align
   [
    "-version", Unit print_version , " Display the version";
@@ -257,8 +270,8 @@ let spec = ref (
    "-build-dir", String set_build_dir, "<path> Set build directory (implies no-links)";
    "-install-lib-dir", Set_string Ocamlbuild_where.libdir, "<path> Set the install library directory";
    "-install-bin-dir", Set_string Ocamlbuild_where.bindir, "<path> Set the install binary directory";
-   "-where", Unit (fun () -> print_endline !Ocamlbuild_where.libdir; raise Exit_OK), " Display the install library directory";
-   "-which", String (fun cmd -> print_endline (find_tool cmd); raise Exit_OK), "<command> Display path to the tool command";
+   "-where", Unit (fun () -> sb (); print_endline (slashify !Ocamlbuild_where.libdir); raise Exit_OK), " Display the install library directory";
+   "-which", String (fun cmd -> sb (); print_endline (slashify (find_tool cmd)); raise Exit_OK), "<command> Display path to the tool command";
    "-ocamlc", set_cmd ocamlc, "<command> Set the OCaml bytecode compiler";
    "-plugin-ocamlc", set_cmd plugin_ocamlc, "<command> Set the OCaml bytecode compiler \
      used when building myocamlbuild.ml (only)";

--- a/src/pathname.ml
+++ b/src/pathname.ml
@@ -84,6 +84,26 @@ let rec normalize_list = function
   | x :: xs -> x :: normalize_list xs
 
 let normalize x =
+  let x =
+    if Sys.win32 = false then
+      x
+    else
+      let len = String.length x in
+      let b = Bytes.create len in
+      for i = 0 to pred len do
+        match x.[i] with
+        | '\\' -> Bytes.set b i '/'
+        | c -> Bytes.set b i c
+      done;
+      if len > 1 then (
+        let c1 = Bytes.get b 0 in
+        let c2 = Bytes.get b 1 in
+        if c2 = ':' && c1 >= 'a' && c1 <= 'z' &&
+           ( len = 2 || Bytes.get b 2 = '/') then
+          Bytes.set b 0 (Char.uppercase_ascii c1)
+      );
+      Bytes.unsafe_to_string b
+  in
   if Glob.eval not_normal_form_re x then
     let root, paths = split x in
     join root (normalize_list paths)


### PR DESCRIPTION
This is a straight import of the patch used to fix ocamlbuild on windows inside opam-repository.

Opened as a Draft for now. 

I've imported it on top of #329 so that we can have a CI.
I've added a commit to make the testsuite pass again on my machine.
