### PR TITLE
Small cleanup

### DIFF
--- a/src/command.ml
+++ b/src/command.ml
@@ -94,7 +94,7 @@ let atomize_paths l = S(List.map (fun x -> P x) l)
 let env_path = lazy begin
   let path_var = Sys.getenv "PATH" in
   let parse_path =
-    if Sys.os_type = "Win32" then
+    if Sys.win32 then
       Lexers.parse_environment_path_w
     else
       Lexers.parse_environment_path
@@ -149,7 +149,7 @@ let rec string_of_command_spec_with_calls call_with_tags call_with_target resolv
   let b = Buffer.create 256 in
   (* The best way to prevent bash from switching to its windows-style
    * quote-handling is to prepend an empty string before the command name. *)
-  if Sys.os_type = "Win32" then
+  if Sys.win32 then
     Buffer.add_string b "''";
   let first = ref true in
   let put_space () =
@@ -260,7 +260,7 @@ let flatten_commands quiet pretend cmd =
 
 let execute_many ?(quiet=false) ?(pretend=false) cmds =
   add_parallel_stat (List.length cmds);
-  let degraded = !*My_unix.is_degraded || Sys.os_type = "Win32" in
+  let degraded = !*My_unix.is_degraded || Sys.win32 in
   let jobs = !jobs in
   if jobs < 0 then invalid_arg "jobs < 0";
   let max_jobs = if jobs = 0 then None else Some jobs in

--- a/src/display.ml
+++ b/src/display.ml
@@ -27,7 +27,7 @@ module ANSI =
     let clear_to_eol oc () = fp oc "\027[K";;
     let bol oc () = fp oc "\r";;
     let get_columns () =
-      if Sys.os_type = "Unix" then
+      if Sys.unix then
         try
           int_of_string (String.chomp (My_unix.run_and_read "tput cols"))
         with

--- a/src/lexers.mll
+++ b/src/lexers.mll
@@ -122,7 +122,7 @@ and conf_lines dir source = parse
       {
         let bexpr =
           try Glob.parse ?dir k
-          with exn -> error source lexbuf "Invalid globbing pattern %S" k
+          with _exn -> error source lexbuf "Invalid globbing pattern %S" k
         in
         sublex (count_lines lexbuf) s1; sublex (count_lines lexbuf) s2;
         let v1 = conf_value empty source lexbuf in

--- a/src/my_std.ml
+++ b/src/my_std.ml
@@ -276,26 +276,26 @@ let sys_file_exists x =
       with Exit -> true
 
 let sys_command =
-  match Sys.os_type with
-  | "Win32" -> fun cmd ->
+  match Sys.win32 with
+  | true -> fun cmd ->
       if cmd = "" then 0 else
       let cmd = "bash --norc -c " ^ Filename.quote cmd in
       Sys.command cmd
-  | _ -> fun cmd -> if cmd = "" then 0 else Sys.command cmd
+  | false -> fun cmd -> if cmd = "" then 0 else Sys.command cmd
 
 (* FIXME warning fix and use Filename.concat *)
 let filename_concat x y =
   if x = Filename.current_dir_name || x = "" then y else
-  if Sys.os_type = "Win32" && (x.[String.length x - 1] = '\\') || x.[String.length x - 1] = '/' then
+  if Sys.win32 && (x.[String.length x - 1] = '\\') || x.[String.length x - 1] = '/' then
     if y = "" then x
     else x ^ y
   else
     x ^ "/" ^ y
 
 (* let reslash =
-  match Sys.os_type with
-  | "Win32" -> tr '\\' '/'
-  | _ -> (fun x -> x) *)
+  match Sys.win32 with
+  | true -> tr '\\' '/'
+  | false -> (fun x -> x) *)
 
 open Format
 

--- a/src/ocamlbuild_where.ml
+++ b/src/ocamlbuild_where.ml
@@ -34,7 +34,7 @@ let libdir = ref begin
          OCAMLLIB is already a strange thing to have done). *)
       try
         let normalise_slashes =
-          if Sys.os_type = "Win32" then
+          if Sys.win32 then
             String.map (function '/' -> '\\' | c -> c)
           else
             function s -> s

--- a/src/shell.ml
+++ b/src/shell.ml
@@ -29,7 +29,7 @@ let quote_filename_if_needed s =
   (* We should probably be using [Filename.unix_quote] except that function
    * isn't exported. Users on Windows will have to live with not being able to
    * install OCaml into c:\o'caml. Too bad. *)
-  else if Sys.os_type = "Win32" then Printf.sprintf "'%s'" s
+  else if Sys.win32 then Printf.sprintf "'%s'" s
   else Filename.quote s
 let chdir dir =
   reset_filesys_cache ();
@@ -37,7 +37,7 @@ let chdir dir =
 let run args target =
   reset_readdir_cache ();
   let cmd = String.concat " " (List.map quote_filename_if_needed args) in
-  if !*My_unix.is_degraded || Sys.os_type = "Win32" then
+  if !*My_unix.is_degraded || Sys.win32 then
     begin
       Log.event cmd target Tags.empty;
       let st = sys_command cmd in


### PR DESCRIPTION
- use `Sys.unix` instead of `Sys.os_type = "Unix"`
- use `Sys.win32` instead of `Sys.os_type = "Win32"`
- fix an unused variable warning