### PR TITLE
Add a test case for custom preprocessor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,11 @@ jobs:
       - run: opam exec -- make distclean
       - run: opam exec -- opam pin add -n ocamlbuild .
       - run: opam exec -- opam install -v ocamlbuild
+      - run: opam exec -- opam install -v menhir
+      - run: opam exec -- opam install -v camlp4
+        if: (! startsWith(matrix.ocaml-compiler, '5.2'))
+      - run: opam exec -- make test-external
+        if: (! startsWith(matrix.ocaml-compiler, '5.2'))
       - run: opam exec -- opam install -v mtime.1.0.0 # this tests topkg, with stub libraries
       - run: opam exec -- opam install -v inotify.2.3 # this tests oasis, with stub libraries
         if: (! startsWith(matrix.ocaml-compiler, '5')) && runner.os != 'Windows'

--- a/src/my_std.ml
+++ b/src/my_std.ml
@@ -373,6 +373,19 @@ let sys_command cmd =
   if cmd = "" then 0 else
   sys_command cmd
 
+(* See https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way *)
+let quote_cmd s =
+  let b = Buffer.create (String.length s + 20) in
+  String.iter
+    (fun c ->
+       match c with
+       | '(' | ')' | '!' | '^' | '%' | '\"' | '<' | '>' | '&' | '|' ->
+         Buffer.add_char b '^'; Buffer.add_char b c
+       | _ ->
+         Buffer.add_char b c)
+    s;
+  Buffer.contents b
+
 (* FIXME warning fix and use Filename.concat *)
 let filename_concat x y =
   if x = Filename.current_dir_name || x = "" then y else

--- a/src/my_std.mli
+++ b/src/my_std.mli
@@ -74,6 +74,9 @@ val prepare_command_for_windows : string -> string array
 
 val env_path : string list Lazy.t
 
+val quote_cmd : string -> string
+
 (*/*)
+
 type log = { mutable dprintf : 'a. int -> ('a, Format.formatter, unit) format -> 'a }
 val log : log

--- a/src/signatures.mli
+++ b/src/signatures.mli
@@ -195,9 +195,9 @@ module type COMMAND = sig
                          instance). *)
     | V of string    (** A virtual command, that will be resolved at
                          execution using [resolve_virtuals] *)
-    | Quote of spec  (** A string that should be quoted like a
-                           filename but isn't really one. *)
-
+    | Quote of spec  (** Used for commands or part of commands,
+                        meant to be passed to [Sys.command] at some
+                        point. *)
   (*type v = [ `Seq of v list | `Cmd of vspec | `Nop ]
     and vspec =
     [ `N

--- a/testsuite/external.ml
+++ b/testsuite/external.ml
@@ -34,9 +34,7 @@ let () = test "Camlp4NativePlugin"
 let () = test "SubtoolOptions"
   ~description:"Options that come from tags that needs to be spliced \
                 to the subtool invocation (PR#5763)"
-  (* testing for the 'menhir' executable directly
-     is too hard to do in a portable way; test the ocamlfind package instead *)
-  ~requirements:(req_and (package_exists "menhirLib") (package_exists "camlp4"))
+  ~requirements:(req_and (package_exists "menhir") (package_exists "camlp4"))
   ~options:[`use_ocamlfind; `use_menhir; `tags ["package(camlp4.fulllib)"]]
   ~tree:[T.f "parser.mly"
             ~content:{|

--- a/testsuite/external_test_header.ml
+++ b/testsuite/external_test_header.ml
@@ -2,7 +2,10 @@
    Findlib was loaded in findlibonly_test_header.ml *)
 let package_exists package =
   let open Findlib in
-  try ignore (package_directory package); Fullfilled
+  try
+    let dir = package_directory package in
+    Printf.eprintf "%s found in %s\n%!" package dir;
+    Fullfilled
   with No_such_package _ ->
     Missing (Printf.sprintf "the ocamlfind package %s" package)
 


### PR DESCRIPTION
This use case was found in camlp4 and is likely broken on windows. Let's try to fix.

This PR adds a special handling for `A '-pp'; Quote q`. The command `q` will be executed by `cmd.exe` in `ocamlc/ocamldep/..` and needs to be escaped as such.

Based on #338 and #339

Should fix https://github.com/ocaml/ocamlbuild/issues/89