### PR TITLE
Switch to opam.2.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,9 +54,6 @@ jobs:
           allow-prerelease-opam: true
           dune-cache: true
 
-      - run: opam pin add mingw-w64-shims git+https://github.com/dra27/mingw-w64-shims.git#internals
-        if: runner.os == 'Windows'
-
       - run: opam install . --with-test --deps-only
 
       - run: opam exec -- make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
-        uses: kit-ty-kate/setup-ocaml@win52
+        uses: ocaml/setup-ocaml@v3.0.0-alpha
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           allow-prerelease-opam: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,16 +18,22 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:
-          - "4.08"
-          - "4.09"
-          - "4.10"
-          - "4.11"
-          - "4.12"
           - "4.13"
           - "4.14"
           - "5.0.0"
           - "5.1.1"
           - "5.2.0"
+        include:
+          - os: ubuntu-latest
+            ocaml-compiler: "4.08"
+          - os: ubuntu-latest
+            ocaml-compiler: "4.09"
+          - os: ubuntu-latest
+            ocaml-compiler: "4.10"
+          - os: ubuntu-latest
+            ocaml-compiler: "4.11"
+          - os: ubuntu-latest
+            ocaml-compiler: "4.12"
 
     runs-on: ${{ matrix.os }}
 
@@ -42,39 +48,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
-        if: runner.os == 'Windows' && ! startsWith(matrix.ocaml-compiler, '5')
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          opam-repositories: |
-            default: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
-            opam: https://github.com/ocaml/opam-repository.git
-          dune-cache: true
-          opam-depext: ${{ !matrix.skip-test }}
-          opam-depext-flags: --with-test
-
-      - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
-        if: runner.os == 'Windows' && startsWith(matrix.ocaml-compiler, '5')
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ocaml-variants.${{ matrix.ocaml-compiler }}+options,ocaml-option-mingw
-          opam-repositories: |
-            dra27: https://github.com/dra27/opam-repository.git#windows-5.0
-            default: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
-            opam: https://github.com/ocaml/opam-repository.git
-          dune-cache: true
-          opam-depext: ${{ !matrix.skip-test }}
-          opam-depext-flags: --with-test
-
-      - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
-        if: runner.os != 'Windows'
-        uses: ocaml/setup-ocaml@v2
+        uses: kit-ty-kate/setup-ocaml@win52
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           allow-prerelease-opam: true
           dune-cache: true
-          opam-depext: ${{ !matrix.skip-test }}
-          opam-depext-flags: --with-test
+
+      - run: opam pin add mingw-w64-shims git+https://github.com/dra27/mingw-w64-shims.git#internals
+        if: runner.os == 'Windows'
 
       - run: opam install . --with-test --deps-only
 
@@ -90,5 +71,6 @@ jobs:
       - run: opam exec -- opam install -v inotify.2.3 # this tests oasis, with stub libraries
         if: (! startsWith(matrix.ocaml-compiler, '5')) && runner.os != 'Windows'
       - run: opam exec -- opam install -v cpuid.0.1.1 # this tests the ocb-stubblr plugin
+        if: runner.os != 'Windows'
       - run: opam exec -- opam install -v shcaml.0.2.1 # this tests the cppo plugin
         if: (! startsWith(matrix.ocaml-compiler, '5')) && runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
         ocaml-compiler:
           - "4.13"
           - "4.14"
-          - "5.0.0"
-          - "5.1.1"
-          - "5.2.0"
+          - "5.0"
+          - "5.1"
+          - "5.2"
         include:
           - os: ubuntu-latest
             ocaml-compiler: "4.08"


### PR DESCRIPTION
And no longer rely on patched ocaml compilers from the opam-repository-mingw repo.

The PR removes OCaml 4.08 .. 4.12 on windows from the CI because this setup is not yet available in the upstream opam repo.

- [x] wait for setup-ocaml@v3
- [x] remove mingw-w64-shims pin (https://github.com/ocaml/opam-repository/pull/26123)
- [x] wait for setup-ocaml to include the cygwin path in PATH 