### PR TITLE
No longer call into cmd.exe to execute a posix shell on windows

### DIFF
--- a/.depend
+++ b/.depend
@@ -499,8 +499,10 @@ src/ocaml_utils.cmi : \
 src/ocamlbuild_config.cmo :
 src/ocamlbuild_config.cmx :
 src/ocamlbuild_executor.cmo : \
+    src/my_std.cmi \
     src/ocamlbuild_executor.cmi
 src/ocamlbuild_executor.cmx : \
+    src/my_std.cmx \
     src/ocamlbuild_executor.cmi
 src/ocamlbuild_executor.cmi :
 src/ocamlbuild_where.cmo : \

--- a/.depend
+++ b/.depend
@@ -37,8 +37,6 @@ src/command.cmo : \
     src/my_unix.cmi \
     src/my_std.cmi \
     src/log.cmi \
-    src/lexers.cmi \
-    src/const.cmo \
     src/command.cmi
 src/command.cmx : \
     src/tags.cmx \
@@ -47,8 +45,6 @@ src/command.cmx : \
     src/my_unix.cmx \
     src/my_std.cmx \
     src/log.cmx \
-    src/lexers.cmx \
-    src/const.cmx \
     src/command.cmi
 src/command.cmi : \
     src/tags.cmi \

--- a/src/command.ml
+++ b/src/command.ml
@@ -91,22 +91,6 @@ let atomize l = S(List.map (fun x -> A x) l)
 let atomize_paths l = S(List.map (fun x -> P x) l)
 (* ***)
 
-let env_path = lazy begin
-  let path_var = Sys.getenv "PATH" in
-  let parse_path =
-    if Sys.win32 then
-      Lexers.parse_environment_path_w
-    else
-      Lexers.parse_environment_path
-  in
-  let paths =
-    parse_path Const.Source.path (Lexing.from_string path_var) in
-  let norm_current_dir_name path =
-    if path = "" then Filename.current_dir_name else path
-  in
-  List.map norm_current_dir_name paths
-end
-
 let virtual_solvers = Hashtbl.create 32
 let setup_virtual_command_solver virtual_command solver =
   Hashtbl.replace virtual_solvers virtual_command solver
@@ -136,7 +120,7 @@ let search_in_path cmd =
     else file_or_exe_exists (filename_concat path cmd)
   in
   if Filename.is_implicit cmd then
-    let path = List.find try_path !*env_path in
+    let path = List.find try_path !*My_std.env_path in
     (* We're not trying to append ".exe" here because all windows shells are
      * capable of understanding the command without the ".exe" suffix. *)
     filename_concat path cmd

--- a/src/lexers.mli
+++ b/src/lexers.mli
@@ -28,15 +28,6 @@ val comma_sep_strings : Loc.source -> Lexing.lexbuf -> string list
 val comma_or_blank_sep_strings : Loc.source -> Lexing.lexbuf -> string list
 val trim_blanks : Loc.source -> Lexing.lexbuf -> string
 
-(* Parse an environment path (i.e. $PATH).
-   This is a colon separated string.
-   Note: successive colons means an empty string.
-   Example:
-      ":aaa:bbb:::ccc:" -> [""; "aaa"; "bbb"; ""; ""; "ccc"; ""] *)
-val parse_environment_path : Loc.source -> Lexing.lexbuf -> string list
-(* Same one, for Windows (PATH is ;-separated) *)
-val parse_environment_path_w : Loc.source -> Lexing.lexbuf -> string list
-
 val conf_lines : string option -> Loc.source -> Lexing.lexbuf -> conf
 val path_scheme : bool -> Loc.source -> Lexing.lexbuf ->
   [ `Word of string

--- a/src/lexers.mll
+++ b/src/lexers.mll
@@ -95,24 +95,6 @@ and comma_or_blank_sep_strings_aux source = parse
   | space* eof { [] }
   | _ { error source lexbuf "Expecting (comma|blank)-separated strings (2)" }
 
-and parse_environment_path_w source = parse
-  | ([^ ';']* as word) { word :: parse_environment_path_aux_w source lexbuf }
-  | ';' ([^ ';']* as word) { "" :: word :: parse_environment_path_aux_w source lexbuf }
-  | eof { [] }
-and parse_environment_path_aux_w source = parse
-  | ';' ([^ ';']* as word) { word :: parse_environment_path_aux_w source lexbuf }
-  | eof { [] }
-  | _ { error source lexbuf "Impossible: expecting colon-separated strings" }
-
-and parse_environment_path source = parse
-  | ([^ ':']* as word) { word :: parse_environment_path_aux source lexbuf }
-  | ':' ([^ ':']* as word) { "" :: word :: parse_environment_path_aux source lexbuf }
-  | eof { [] }
-and parse_environment_path_aux source = parse
-  | ':' ([^ ':']* as word) { word :: parse_environment_path_aux source lexbuf }
-  | eof { [] }
-  | _ { error source lexbuf "Impossible: expecting colon-separated strings" }
-
 and conf_lines dir source = parse
   | space* '#' not_newline* newline { Lexing.new_line lexbuf; conf_lines dir source lexbuf }
   | space* '#' not_newline* eof { [] }

--- a/src/log.ml
+++ b/src/log.ml
@@ -79,3 +79,5 @@ let finish ?how () =
   | Some d -> Display.finish ?how d
 
 (*let () = My_unix.at_exit_once finish*)
+
+let () = My_std.log3 := (fun s -> dprintf 3 "%s\n%!" s)

--- a/src/my_std.ml
+++ b/src/my_std.ml
@@ -291,6 +291,9 @@ let split_path_win str =
   in
   aux 0
 
+(* Here to break the circular dep *)
+let log3 = ref (fun _ -> failwith "My_std.log3 not initialized")
+
 let windows_shell = lazy begin
   let rec iter = function
   | [] -> [| "bash.exe" ; "--norc" ; "--noprofile" |]
@@ -305,7 +308,7 @@ let windows_shell = lazy begin
   in
   let paths = split_path_win (try Sys.getenv "PATH" with Not_found -> "") in
   let res = iter paths in
-  if false then Printf.eprintf "Using shell %s\n%!" (Array.to_list res |> String.concat " ");
+  !log3 (Printf.sprintf "Using shell %s" (Array.to_list res |> String.concat " "));
   res
 end
 

--- a/src/my_std.ml
+++ b/src/my_std.ml
@@ -327,6 +327,9 @@ let windows_shell = lazy begin
 end
 
 let prepare_command_for_windows cmd =
+  (* The best way to prevent bash from switching to its windows-style
+   * quote-handling is to prepend an empty string before the command name. *)
+  let cmd = "''" ^ cmd in
   Array.append (Lazy.force windows_shell) [|"-c"; cmd|]
 
 let sys_command_win32 cmd =

--- a/src/my_std.ml
+++ b/src/my_std.ml
@@ -275,7 +275,8 @@ let sys_file_exists x =
       try Array.iter (fun x -> if x = basename then raise Exit) a; false
       with Exit -> true
 
-(* https://github.com/ocaml/opam/blame/master/src/core/opamStd.ml *)
+(* Copied from opam
+   https://github.com/ocaml/opam/blob/ca32ab3b976aa7abc00c7605548f78a30980d35b/src/core/opamStd.ml *)
 let split_quoted path sep =
     let length = String.length path in
     let rec f acc index current last normal =
@@ -298,7 +299,7 @@ let split_quoted path sep =
 
 let env_path = lazy begin
   let path_var = (try Sys.getenv "PATH" with Not_found -> "") in
-  (* OPAM doesn't support empty path to mean working directory, let's
+  (* opam doesn't support empty path to mean working directory, let's
      do the same here *)
   if Sys.win32 then
     split_quoted path_var ';'

--- a/src/my_std.mli
+++ b/src/my_std.mli
@@ -71,3 +71,6 @@ val split_ocaml_version : (int * int * int * string) option
 (** (major, minor, patchlevel, rest) *)
 
 val prepare_command_for_windows : string -> string array
+
+(*/*)
+val log3 : (string -> unit) ref

--- a/src/my_std.mli
+++ b/src/my_std.mli
@@ -69,3 +69,5 @@ val lexbuf_of_string : ?name:string -> string -> Lexing.lexbuf
 
 val split_ocaml_version : (int * int * int * string) option
 (** (major, minor, patchlevel, rest) *)
+
+val prepare_command_for_windows : string -> string array

--- a/src/my_std.mli
+++ b/src/my_std.mli
@@ -72,5 +72,7 @@ val split_ocaml_version : (int * int * int * string) option
 
 val prepare_command_for_windows : string -> string array
 
+val env_path : string list Lazy.t
+
 (*/*)
 val log3 : (string -> unit) ref

--- a/src/my_unix.ml
+++ b/src/my_unix.ml
@@ -58,15 +58,12 @@ let at_exit_once callback =
   end
 
 let run_and_open s kont =
-  let s =
-    (* Be consistent! My_unix.run_and_open uses My_std.sys_command and
-       sys_command uses bash. *)
-    if Sys.win32 then
-      "bash --norc -c " ^ Filename.quote s
-    else
-      s
-  in
-  let ic = Unix.open_process_in s in
+  let ic =
+    if Sys.win32
+    then
+      let args = My_std.prepare_command_for_windows s in
+      Unix.open_process_args_in args.(0) args
+    else Unix.open_process_in s in
   let close () =
     match Unix.close_process_in ic with
     | Unix.WEXITED 0 -> ()

--- a/src/ocamlbuild_executor.ml
+++ b/src/ocamlbuild_executor.ml
@@ -136,13 +136,13 @@ let execute
   (* ***)
   (*** add_job *)
   let add_job cmd rest result id =
-    let cmd =
-      if Sys.win32
-      then "bash --norc -c " ^ Filename.quote cmd
-      else cmd
-    in
     (*display begin fun oc -> fp oc "Job %a is %s\n%!" print_job_id id cmd; end;*)
-    let (stdout', stdin', stderr') = open_process_full cmd env in
+    let (stdout', stdin', stderr') =
+      if Sys.win32
+      then
+        let args = My_std.prepare_command_for_windows cmd in
+        open_process_args_full args.(0) args (Unix.environment ())
+      else open_process_full cmd env in
     incr jobs_active;
     if not Sys.win32 then begin
       set_nonblock (doi stdout');

--- a/src/ocamlbuild_executor.ml
+++ b/src/ocamlbuild_executor.ml
@@ -141,7 +141,7 @@ let execute
       if Sys.win32
       then
         let args = My_std.prepare_command_for_windows cmd in
-        open_process_args_full args.(0) args (Unix.environment ())
+        open_process_args_full args.(0) args env
       else open_process_full cmd env in
     incr jobs_active;
     if not Sys.win32 then begin


### PR DESCRIPTION
based on top of #338 
Inspired by #330.
`Sys.command`, `Unix.open_process_in`, `Unix.open_process_full` all go through `cmd.exe` to execute the given command.
In our case, it means we call cmd.exe to call bash.
This is unnecessary, and complicate things. We can directly call a posix shell and not have to worry about another layer of escaping.

In this PR, we use `open_process_args*` funtions to avoid going through `cmd.exe`