### PR TITLE
Get the compiler configuration at runtime (useful for cross-compiling)

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,11 @@ of the usual "- ".
 NEXT_RELEASE:
 -------------
 
+- Set default values of `Options.ext_*` and `Options.exe` from the output of
+  `Options.ocamlc "-config"` (Useful when `Options.ocamlc` is a cross compiler)
+  (#353 by Pierre Boutillier, reviewed by Kate Deplaix and Hugo Heuzard,
+   requested by whitequark in #181)
+
 0.15.0 (29 Jun 2024):
 ----------------------
 OCamlbuild 0.15.0 comes with first class support for native Windows ports of OCaml

--- a/src/command.ml
+++ b/src/command.ml
@@ -291,6 +291,10 @@ let execute ?quiet ?pretend cmd =
   | Some(_, exn) -> raise exn
   | _ -> ()
 
+let run_and_read ?(quiet=false) cmd =
+  let kont = string_print_of_command_spec cmd quiet false in
+  My_unix.run_and_read (kont ())
+
 let iter_tags f x =
   let rec spec x =
     match x with

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -15,7 +15,6 @@
 (* Original author: Romain Bardou *)
 
 open My_std
-open My_unix
 open Command
 
 type command_spec = Command.spec
@@ -63,11 +62,11 @@ let packages = Hashtbl.create 42
 
 let run_and_parse lexer command =
   Printf.ksprintf
-    (fun command -> lexer & Lexing.from_string & run_and_read command)
+    (fun command -> lexer & Lexing.from_string & My_unix.run_and_read command)
     command
 
 let run_and_read command =
-  Printf.ksprintf run_and_read command
+  Printf.ksprintf My_unix.run_and_read command
 
 let rec query name =
   try

--- a/src/options.ml
+++ b/src/options.ml
@@ -400,7 +400,10 @@ let init () =
 
   ignore_list := List.map String.capitalize_ascii !ignore_list;
 
-  let raw_ocamlc_config = Command.run_and_read (S [!ocamlc ; A "-config" ]) in
+  let raw_ocamlc_config =
+    try Command.run_and_read (S [!ocamlc; A "-config"])
+    with Failure _ -> Command.run_and_read (S [!ocamlopt; A "-config"])
+  in
   let ocamlc_config_lines = String.split_on_char '\n' raw_ocamlc_config in
   let ocamlc_configs =
     List.filter_map

--- a/src/options.ml
+++ b/src/options.ml
@@ -415,13 +415,21 @@ let init () =
          | [ k; v ] -> Some (k, String.trim v)
          | _ -> None)
       ocamlc_config_lines in
-  let get_ext x =
-    let s = List.assoc x ocamlc_configs in
-    if String.length s > 0 then String.after s 1 else s in
-  ext_lib := get_ext "ext_lib";
-  ext_obj := get_ext "ext_obj";
-  ext_dll := get_ext "ext_dll";
-  exe := List.assoc "ext_exe" ocamlc_configs;
+  let get_field k =
+    match List.assoc_opt (k : string) ocamlc_configs with
+    | Some s -> s
+    | None -> failwith (k^" could not be found in ocamlc -config")
+  in
+  let extract_ext s =
+    if String.length s > 0 && s.[0] = '.' then
+      String.after s 1
+    else
+      s
+  in
+  ext_lib := extract_ext (get_field "ext_lib");
+  ext_obj := extract_ext (get_field "ext_obj");
+  ext_dll := extract_ext (get_field "ext_dll");
+  exe := get_field "ext_exe";
 ;;
 
 (* The current heuristic: we know we are in an ocamlbuild project if

--- a/src/signatures.mli
+++ b/src/signatures.mli
@@ -219,6 +219,9 @@ module type COMMAND = sig
   (** Will convert a string list to a list of paths by adding [P] constructors. *)
   val atomize_paths : string list -> spec
 
+  (** Run the command specification and returns its output *)
+  val run_and_read : ?quiet:bool -> spec -> string
+
   (** Run the command. *)
   val execute : ?quiet:bool -> ?pretend:bool -> t -> unit
 


### PR DESCRIPTION
Fixes #181 (in a minimal way)

The revival of cross compilation by ocaml/ocaml#13526 begs for it ;) 

More seriously, a reproduction scenario cannot really be very minimal as it suppose to have a cross compiler installed but 
1/ suppose you have one thanks to https://github.com/ocaml-cross/opam-cross-windows
2/ do `opam source uutf` and `cd [it]`
3/ try to cross compile it with `ocaml pkg/pkg.ml build --toolchain windows --pkg-name uutf --dev-pkg false` 
(4/ it calls internally 
```
'ocamlbuild' '-use-ocamlfind' '-classic-display' '-toolchain' 'windows'
     '-j' '4' '-tag' 'debug' '-build-dir' '_build' 'opam' 'pkg/META'
     'CHANGES.md' 'LICENSE.md' 'README.md' 'src/uutf.lib' 'src/uutf.cmxs'
     'src/uutf.cmxa' 'src/uutf.cma' 'src/uutf.cmx' 'src/uutf.cmi'
     'src/uutf.mli' 'test/utftrip.native'
```
)
witch fails with
```
Solver failed:
  Ocamlbuild knows of no rules that apply to a target named src/uutf.lib. This can happen if you ask Ocamlbuild to build a target with the wrong extension (e.g. .opt instead of .native) or if the source files live in directories that have not been specified as include directories.
```
because "host" (linux/macos) ocamlbuild hardwired that `ext_lib = .a` while no actually the compiler ocamlbuild would use has `ext_lib = .lib` and therefore it knows how to build `.lib`!

~Ask for feedback:
As it, the test `NativeMliCmi` is broken. This test sets ocamlc to `toto` in order to ensure that any call to ocamlc fails (aka ocamlc is not called, ocamlopt is) and obviously with my patch, ocamlc is called! What should I do? Chance the test? (how?) or make my code way more complex by handling the case where `$OCAMLC -config` fails but `$OCAMLOPT -config` succeed?~ (Thank you @kit-ty-kate )