### PR TITLE
Remove symbolic link from the repo

### DIFF
--- a/examples/07-dependent-projects/.gitignore
+++ b/examples/07-dependent-projects/.gitignore
@@ -1,0 +1,1 @@
+libdemo

--- a/examples/07-dependent-projects/Makefile
+++ b/examples/07-dependent-projects/Makefile
@@ -16,11 +16,15 @@ all: native byte
 
 clean:
 	$(OCB) -clean
+	rm -f libdemo
 
-native:
+libdemo:
+	ln -sf ../04-library/libdemo libdemo
+
+native: libdemo
 	$(OCB) main.native
 
-byte:
+byte: libdemo
 	$(OCB) main.byte
 
 profile:

--- a/examples/07-dependent-projects/libdemo
+++ b/examples/07-dependent-projects/libdemo
@@ -1,1 +1,0 @@
-../04-library/libdemo


### PR DESCRIPTION
The symbolic link in `examples/07-dependent-projects/libdemo` can create problems on Windows - there's mitigations in opam for them (cf. things like https://github.com/ocaml/opam/pull/5793) and workaround needed in `dune pkg` (cf.  https://github.com/Leonidas-from-XIV/ocamlbuild/commit/80cdf58c365bc56d427febf9c99d2423356c2faf).

Simplest approach to me seems to be to delete it and have the `Makefile` infrastructure put it in place. It doesn't look to me as though these examples were ever intended to have `ocamlbuild` invoked directly (i.e. it looks the aim is that the user invokes `make` to run them).